### PR TITLE
Support running Fendermint on Bitcoin rootnet

### DIFF
--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -259,7 +259,7 @@ rate_limit_period = 0
 # IPC related configuration parameters
 [ipc]
 # Default subnet ID, which basically means IPC is disabled.
-subnet_id = "/r0"
+subnet_id = "/eip155:0"
 # Voting interval about things such as the top-down finality, in seconds.
 # It's limited to avoid GossipSub throttling or banning the node for over production.
 # The minimum is 1 seconds which is about the minimum target block time as well;

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -259,7 +259,7 @@ rate_limit_period = 0
 # IPC related configuration parameters
 [ipc]
 # Default subnet ID, which basically means IPC is disabled.
-subnet_id = "/eip155:0"
+subnet_id = "/r0"
 # Voting interval about things such as the top-down finality, in seconds.
 # It's limited to avoid GossipSub throttling or banning the node for over production.
 # The minimum is 1 seconds which is about the minimum target block time as well;

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand, ValueEnum};
-use ipc_api::{subnet_id::SubnetID, universal_subnet_id::UniversalSubnetId};
+use ipc_api::subnet_id::SubnetID;
 
 use super::parse::{
     parse_eth_address, parse_full_fil, parse_network_version, parse_percentage, parse_signer_addr,
@@ -209,7 +209,7 @@ pub struct GenesisIpcGatewayArgs {
 pub struct GenesisFromParentArgs {
     /// Child subnet for with the genesis file is being created
     #[arg(long, short)]
-    pub subnet_id: UniversalSubnetId,
+    pub subnet_id: SubnetID,
 
     /// Endpoint to the RPC of the child subnet's parent
     #[arg(long, short)]

--- a/fendermint/app/options/src/lib.rs
+++ b/fendermint/app/options/src/lib.rs
@@ -62,7 +62,7 @@ fn set_env_from_aliases() {
 #[derive(Args, Debug)]
 pub struct GlobalArgs {
     /// Set the FVM Address Network. It's value affects whether `f` (main) or `t` (test) prefixed addresses are accepted.
-    #[arg(short, long, default_value = "mainnet", env = "FM_NETWORK", value_parser = parse_network)]
+    #[arg(short, long, default_value = "testnet", env = "FM_NETWORK", value_parser = parse_network)]
     pub network: Network,
 }
 

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -7,6 +7,7 @@ use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use ipc_api::subnet_id::SubnetID;
+use ipc_api::universal_subnet_id::UniversalSubnetId;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
 use std::fmt::{Display, Formatter};
@@ -40,6 +41,7 @@ pub mod utils;
 struct IsHumanReadable;
 
 human_readable_str!(SubnetID);
+human_readable_str!(UniversalSubnetId);
 human_readable_delegate!(TokenAmount);
 
 #[derive(Debug, Deserialize, Clone)]
@@ -199,7 +201,7 @@ pub struct TopDownSettings {
 #[derive(Debug, Deserialize, Clone)]
 pub struct IpcSettings {
     #[serde_as(as = "IsHumanReadable")]
-    pub subnet_id: SubnetID,
+    pub subnet_id: UniversalSubnetId,
     /// Interval with which votes can be gossiped.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub vote_interval: Duration,
@@ -302,7 +304,9 @@ impl Settings {
     /// then overrides from the local environment,
     /// finally parse it into the [Settings] type.
     pub fn new(config_dir: &Path, home_dir: &Path, run_mode: &str) -> Result<Self, ConfigError> {
-        Self::config(config_dir, home_dir, run_mode).and_then(Self::parse)
+        let config = Self::config(config_dir, home_dir, run_mode)?;
+        println!("fenderming Settings::new config = {config:#?}");
+        Self::parse(config)
     }
 
     /// Load the configuration into a generic data structure.
@@ -373,7 +377,7 @@ impl Settings {
     /// Indicate whether we have configured the IPLD Resolver to run.
     pub fn resolver_enabled(&self) -> bool {
         !self.resolver.connection.listen_addr.is_empty()
-            && self.ipc.subnet_id != *ipc_api::subnet_id::UNDEF
+            && self.ipc.subnet_id != *ipc_api::universal_subnet_id::UNDEF
     }
 }
 

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -201,7 +201,7 @@ pub struct TopDownSettings {
 #[derive(Debug, Deserialize, Clone)]
 pub struct IpcSettings {
     #[serde_as(as = "IsHumanReadable")]
-    pub subnet_id: UniversalSubnetId,
+    pub subnet_id: SubnetID,
     /// Interval with which votes can be gossiped.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub vote_interval: Duration,
@@ -377,7 +377,7 @@ impl Settings {
     /// Indicate whether we have configured the IPLD Resolver to run.
     pub fn resolver_enabled(&self) -> bool {
         !self.resolver.connection.listen_addr.is_empty()
-            && self.ipc.subnet_id != *ipc_api::universal_subnet_id::UNDEF
+            && self.ipc.subnet_id != *ipc_api::subnet_id::UNDEF
     }
 }
 

--- a/fendermint/app/src/cmd/debug.rs
+++ b/fendermint/app/src/cmd/debug.rs
@@ -6,7 +6,6 @@ use fendermint_app_options::debug::{
     DebugArgs, DebugCommands, DebugExportTopDownEventsArgs, DebugIpcCommands,
 };
 use fendermint_vm_topdown::proxy::IPCProviderProxy;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_provider::{
     config::subnet::{EVMSubnet, SubnetConfig},
     IpcProvider,
@@ -38,7 +37,6 @@ async fn export_topdown_events(args: &DebugExportTopDownEventsArgs) -> anyhow::R
         .subnet_id
         .parent()
         .ok_or_else(|| anyhow!("subnet is not a child"))?;
-    let subnet_id = UniversalSubnetId::from_subnet_id(&subnet_id);
 
     // Configuration for the child subnet on the parent network,
     // based on how it's done in `run.rs` and the `genesis ipc from-parent` command.

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -342,10 +342,14 @@ async fn new_genesis_from_parent(
         }
     };
 
+    println!("config: {:#?}", config);
+
     let subnet_id = args
         .subnet_id
         .parent()
         .ok_or_else(|| anyhow!("subnet is not a child"))?;
+
+    println!("{}", subnet_id);
 
     let parent_provider = IpcProvider::new_with_subnet(
         None,
@@ -355,9 +359,11 @@ async fn new_genesis_from_parent(
         },
     )?;
 
+    println!("getting genesis_info {:#?}", args.subnet_id);
+
     let genesis_info = parent_provider.get_genesis_info(&args.subnet_id).await?;
 
-    println!("{:#?}", genesis_info);
+    println!("genesis cmd: genesis_info = {:?}", genesis_info);
 
     let subnet_id = args
         .subnet_id

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -4,7 +4,7 @@
 use anyhow::{anyhow, Context};
 use fendermint_crypto::PublicKey;
 use fvm_shared::address::Address;
-use ipc_api::universal_subnet_id::ChainType;
+use ipc_api::subnet_id::NetworkType;
 use ipc_provider::config::subnet::{BTCSubnet, EVMSubnet, SubnetConfig};
 use ipc_provider::IpcProvider;
 use std::path::PathBuf;
@@ -322,14 +322,14 @@ async fn new_genesis_from_parent(
 ) -> anyhow::Result<()> {
     // provider with the parent.
     let config = match args.subnet_id.parent_network_type() {
-        Some(ChainType::Fevm) => SubnetConfig::Fevm(EVMSubnet {
+        Some(NetworkType::Fevm) => SubnetConfig::Fevm(EVMSubnet {
             provider_http: args.parent_endpoint.clone(),
             provider_timeout: None,
             auth_token: args.parent_auth_token.clone(),
             registry_addr: args.parent_registry,
             gateway_addr: args.parent_gateway,
         }),
-        Some(ChainType::Btc) => SubnetConfig::Btc(BTCSubnet {
+        Some(NetworkType::Btc) => SubnetConfig::Btc(BTCSubnet {
             provider_http: args.parent_endpoint.clone(),
             provider_timeout: None,
             auth_token: args.parent_auth_token.clone(),
@@ -365,16 +365,10 @@ async fn new_genesis_from_parent(
 
     println!("genesis cmd: genesis_info = {:?}", genesis_info);
 
-    let subnet_id = args
-        .subnet_id
-        .to_subnet_id()
-        // TODO temporary empty subnet id for non-eip155 chains
-        .unwrap_or(ipc_api::subnet_id::SubnetID::default());
-
     // get gateway genesis
     let ipc_params = ipc::IpcParams {
         gateway: ipc::GatewayParams {
-            subnet_id,
+            subnet_id: args.subnet_id.clone(),
             bottom_up_check_period: genesis_info.bottom_up_checkpoint_period,
             majority_percentage: genesis_info.majority_percentage,
             active_validators_limit: genesis_info.active_validators_limit,

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -119,5 +119,7 @@ fn settings(opts: &Options) -> anyhow::Result<Settings> {
     let settings =
         Settings::new(&config_dir, &opts.home_dir, &opts.mode).context("error parsing settings")?;
 
+    println!("fendermint settings = {settings:#?}");
+
     Ok(settings)
 }

--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -21,7 +21,7 @@ use fendermint_vm_genesis::{
     Account, Actor, ActorMeta, Collateral, Genesis, SignerAddr, Validator, ValidatorKey,
 };
 use fvm_shared::{bigint::Zero, chainid::ChainID, econ::TokenAmount, version::NetworkVersion};
-use ipc_api::{subnet_id::SubnetID, universal_subnet_id::UniversalSubnetId};
+use ipc_api::subnet_id::SubnetID;
 use ipc_provider::config::subnet::{
     EVMSubnet, Subnet as IpcCliSubnet, SubnetConfig as IpcCliSubnetConfig,
 };
@@ -511,7 +511,7 @@ impl DockerMaterializer {
         // Create a `config.toml`` file for the `ipc-cli` based on the deployment of the parent.
         self.update_ipc_cli_config(&testnet_name, |config| {
             config.add_subnet(IpcCliSubnet {
-                id: UniversalSubnetId::from_subnet_id(&subnet_id),
+                id: subnet_id,
                 config: IpcCliSubnetConfig::Fevm(EVMSubnet {
                     provider_http: url,
                     provider_timeout: Some(Duration::from_secs(30)),

--- a/fendermint/vm/actor_interface/src/ipc.rs
+++ b/fendermint/vm/actor_interface/src/ipc.rs
@@ -275,6 +275,17 @@ pub fn subnet_id_to_eth(subnet_id: &SubnetID) -> Result<(u64, Vec<et::Address>),
             {
                 EthAddress(da.subaddress().try_into().expect("checked length"))
             }
+            // To conform to the Ethereum address length, we take the first 20 bytes
+            // of the txid (which has 32 bytes).
+            // This is how subnet id is represented in the Solidity contracts.
+            //
+            // TODO(btc) see if something is relying on these addresses being real.
+            Payload::Delegated(da)
+                if da.namespace() == ipc_api::subnet_id::BTC_NAMESPACE
+                    && da.subaddress().len() == 32 =>
+            {
+                EthAddress(da.subaddress()[..20].try_into().expect("checked length"))
+            }
             _ => return Err(AddressError::InvalidPayload),
         };
         route.push(et::H160::from(addr.0))

--- a/fendermint/vm/interpreter/src/genesis.rs
+++ b/fendermint/vm/interpreter/src/genesis.rs
@@ -565,6 +565,8 @@ fn deploy_contracts(
             GatewayParams::new(SubnetID::new(config.chain_id.into(), vec![]))
         };
 
+        println!("fendermint vm genesis deploy contracts ipc_params={ipc_params:#?}");
+
         let params = ConstructorParameters::new(ipc_params, validators)
             .context("failed to create gateway constructor")?;
 

--- a/fendermint/vm/topdown/src/proxy.rs
+++ b/fendermint/vm/topdown/src/proxy.rs
@@ -10,6 +10,7 @@ use fvm_shared::clock::ChainEpoch;
 use ipc_api::cross::IpcEnvelope;
 use ipc_api::staking::StakingChangeRequest;
 use ipc_api::subnet_id::SubnetID;
+use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_observability::emit;
 use ipc_provider::manager::{GetBlockHashResult, TopDownQueryPayload};
 use ipc_provider::IpcProvider;
@@ -43,6 +44,7 @@ pub trait ParentQueryProxy {
 }
 
 /// The proxy to the subnet's parent
+// TODO(bitcoin) switch to UniversalSubnetId
 pub struct IPCProviderProxy {
     ipc_provider: IpcProvider,
     /// The parent subnet for the child subnet we are target. We can derive from child subnet,
@@ -75,7 +77,8 @@ impl ParentQueryProxy for IPCProviderProxy {
     /// Get the genesis epoch of the child subnet, i.e. the epoch that the subnet was created in
     /// the parent subnet.
     async fn get_genesis_epoch(&self) -> anyhow::Result<BlockHeight> {
-        let height = self.ipc_provider.genesis_epoch(&self.child_subnet).await?;
+        let child_subnet_id = UniversalSubnetId::from_subnet_id(&self.child_subnet);
+        let height = self.ipc_provider.genesis_epoch(&child_subnet_id).await?;
         Ok(height as BlockHeight)
     }
 

--- a/fendermint/vm/topdown/src/proxy.rs
+++ b/fendermint/vm/topdown/src/proxy.rs
@@ -10,7 +10,6 @@ use fvm_shared::clock::ChainEpoch;
 use ipc_api::cross::IpcEnvelope;
 use ipc_api::staking::StakingChangeRequest;
 use ipc_api::subnet_id::SubnetID;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_observability::emit;
 use ipc_provider::manager::{GetBlockHashResult, TopDownQueryPayload};
 use ipc_provider::IpcProvider;
@@ -77,8 +76,7 @@ impl ParentQueryProxy for IPCProviderProxy {
     /// Get the genesis epoch of the child subnet, i.e. the epoch that the subnet was created in
     /// the parent subnet.
     async fn get_genesis_epoch(&self) -> anyhow::Result<BlockHeight> {
-        let child_subnet_id = UniversalSubnetId::from_subnet_id(&self.child_subnet);
-        let height = self.ipc_provider.genesis_epoch(&child_subnet_id).await?;
+        let height = self.ipc_provider.genesis_epoch(&&self.child_subnet).await?;
         Ok(height as BlockHeight)
     }
 

--- a/infra/fendermint/Makefile.toml
+++ b/infra/fendermint/Makefile.toml
@@ -17,8 +17,9 @@ default_to_workspace = false
 [env]
 # General network-specific parameters
 SUBNET_ID = { value = "/r0", condition = { env_not_set = ["SUBNET_ID"] } }
-# The network name is derived from the SUBNET_ID, replacing slashes with dashes, and dropping the first dash if any.
-NETWORK_NAME = { script = ["echo $SUBNET_ID | sed -e 's|/|-|g' -e 's|^-||1'"] }
+# The network name is derived from the SUBNET_ID
+# Replacing slashes with dashes, colons with underscores and dropping the first dash if any.
+NETWORK_NAME = { script = ["echo $SUBNET_ID | sed -e 's|/|-|g' -e 's|:|_|g' -e 's|^-||1'"] }
 # External P2P address advertised by CometBFT to other peers.
 CMT_P2P_EXTERNAL_ADDR = { value = "", condition = { env_not_set = ["CMT_P2P_EXTERNAL_ADDR"] } }
 CMT_P2P_HOST_PORT = { value = "26656", condition = { env_not_set = ["CMT_P2P_HOST_PORT"] } }
@@ -96,7 +97,6 @@ CMT_DOCKER_IMAGE = "cometbft/cometbft:v0.37.x"
 FM_DOCKER_TAG = "latest"
 FM_DOCKER_IMAGE = "fendermint:${FM_DOCKER_TAG}"
 FM_REMOTE_DOCKER_IMAGE = "ghcr.io/consensus-shipyard/fendermint:${FM_DOCKER_TAG}"
-PARENT_NETWORK_TYPE = "fvm"
 PROMTAIL_DOCKER_IMAGE = "grafana/promtail:latest"
 # If this wasn't present, any wait task is skipped.
 CARGO_MAKE_WAIT_MILLISECONDS = 5000

--- a/infra/fendermint/scripts/fendermint.toml
+++ b/infra/fendermint/scripts/fendermint.toml
@@ -12,6 +12,7 @@ script = """
 """
 
 [tasks.fendermint-run]
+# TODO recheck --publish
 script.main = """
 docker run \
   ${FLAGS} \
@@ -19,6 +20,7 @@ docker run \
   --init \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
+  --publish 3030:3030 \
   --volume ${BASE_DIR}:/data \
   --volume fendermint-logs:/fendermint/logs \
   --env-file ${ENV_FILE} \
@@ -43,12 +45,14 @@ extend = "fendermint-run-validator"
 env = { "CMD" = "run", "FLAGS" = "-d" }
 
 [tasks.fendermint-run-validator]
+# TODO recheck --publish
 script = """
 docker run \
   ${FLAGS} \
   --name ${FM_CONTAINER_NAME} \
   --init \
   --user $(id -u) \
+  --publish 3030:3030 \
   --network ${NETWORK_NAME} \
   --volume ${BASE_DIR}:/data \
   --publish ${RESOLVER_HOST_PORT}:${RESOLVER_HOST_PORT} \
@@ -89,12 +93,14 @@ extend = "fendermint-run-subnet"
 env = { "CMD" = "run", "FLAGS" = "-d" }
 
 [tasks.fendermint-run-subnet]
+# TODO recheck --publish
 script = """
 docker run \
   ${FLAGS} \
   --name ${FM_CONTAINER_NAME} \
   --init \
   --user $(id -u) \
+  --publish 3030:3030 \
   --network ${NETWORK_NAME} \
   --volume ${BASE_DIR}:/data \
   --publish ${RESOLVER_HOST_PORT}:${RESOLVER_HOST_PORT} \
@@ -127,11 +133,13 @@ docker run \
 dependencies = ["docker-network-create", "fendermint-deps"]
 
 [tasks.fendermint-tool]
+# TODO recheck --publish
 script.main = """
 docker run \
   ${FLAGS} \
   --init \
   --user $(id -u) \
+  --publish 3030:3030 \
   --volume ${BASE_DIR}:/data \
   --env LOG_LEVEL=${FM_LOG_LEVEL} \
   --env RUST_BACKTRACE=1 \

--- a/infra/fendermint/scripts/fendermint.toml
+++ b/infra/fendermint/scripts/fendermint.toml
@@ -4,7 +4,7 @@ env = { "ENTRY" = "fendermint", "CMD" = "run", "FLAGS" = "-d" }
 
 [tasks.fendermint-pull]
 condition = { env_not_set = [
-  "FM_PULL_SKIP",
+	"FM_PULL_SKIP",
 ], fail_message = "Skipped pulling fendermint Docker image." }
 script = """
   docker pull ghcr.io/consensus-shipyard/fendermint:${FM_DOCKER_TAG}
@@ -12,7 +12,6 @@ script = """
 """
 
 [tasks.fendermint-run]
-# TODO recheck --publish
 script.main = """
 docker run \
   ${FLAGS} \
@@ -20,7 +19,6 @@ docker run \
   --init \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
-  --publish 3030:3030 \
   --volume ${BASE_DIR}:/data \
   --volume fendermint-logs:/fendermint/logs \
   --env-file ${ENV_FILE} \
@@ -45,14 +43,12 @@ extend = "fendermint-run-validator"
 env = { "CMD" = "run", "FLAGS" = "-d" }
 
 [tasks.fendermint-run-validator]
-# TODO recheck --publish
 script = """
 docker run \
   ${FLAGS} \
   --name ${FM_CONTAINER_NAME} \
   --init \
   --user $(id -u) \
-  --publish 3030:3030 \
   --network ${NETWORK_NAME} \
   --volume ${BASE_DIR}:/data \
   --publish ${RESOLVER_HOST_PORT}:${RESOLVER_HOST_PORT} \
@@ -93,14 +89,12 @@ extend = "fendermint-run-subnet"
 env = { "CMD" = "run", "FLAGS" = "-d" }
 
 [tasks.fendermint-run-subnet]
-# TODO recheck --publish
 script = """
 docker run \
   ${FLAGS} \
   --name ${FM_CONTAINER_NAME} \
   --init \
   --user $(id -u) \
-  --publish 3030:3030 \
   --network ${NETWORK_NAME} \
   --volume ${BASE_DIR}:/data \
   --publish ${RESOLVER_HOST_PORT}:${RESOLVER_HOST_PORT} \
@@ -133,13 +127,11 @@ docker run \
 dependencies = ["docker-network-create", "fendermint-deps"]
 
 [tasks.fendermint-tool]
-# TODO recheck --publish
 script.main = """
 docker run \
   ${FLAGS} \
   --init \
   --user $(id -u) \
-  --publish 3030:3030 \
   --volume ${BASE_DIR}:/data \
   --env LOG_LEVEL=${FM_LOG_LEVEL} \
   --env RUST_BACKTRACE=1 \

--- a/infra/fendermint/scripts/subnet.toml
+++ b/infra/fendermint/scripts/subnet.toml
@@ -122,7 +122,7 @@ script.pre = "mkdir -p ${BASE_DIR}/${NODE_NAME}/${KEYS_SUBDIR}; cp ${PRIVATE_KEY
 
 [tasks.subnet-fetch-genesis]
 extend = "fendermint-tool"
-env = { "CMD" = "genesis --genesis-file /data/genesis.json ipc from-parent --subnet-id ${SUBNET_ID} --parent-network-type ${PARENT_NETWORK_TYPE} -p ${PARENT_ENDPOINT}  --parent-gateway ${PARENT_GATEWAY}  --parent-registry ${PARENT_REGISTRY} --base-fee ${BASE_FEE} --power-scale ${POWER_SCALE}" }
+env = { "CMD" = "genesis --genesis-file /data/genesis.json ipc from-parent --subnet-id ${SUBNET_ID} -p ${PARENT_ENDPOINT} --parent-auth-token ${PARENT_AUTH_TOKEN}  --parent-gateway ${PARENT_GATEWAY} --parent-registry ${PARENT_REGISTRY} --base-fee ${BASE_FEE} --power-scale ${POWER_SCALE}" }
 
 [tasks.subnet-genesis-set-eam-permissions]
 extend = "fendermint-tool"

--- a/ipc/api/src/lib.rs
+++ b/ipc/api/src/lib.rs
@@ -37,6 +37,11 @@ pub fn ethers_address_to_fil_address(addr: &ethers::types::Address) -> anyhow::R
     Ok(Address::from(eth_addr))
 }
 
+pub fn token_amount_from_satoshi(sats: impl Into<fvm_shared::bigint::BigInt>) -> TokenAmount {
+    const SATOSHI_TO_ATTO: u64 = 10u64.pow((TokenAmount::DECIMALS as u32) - 8);
+    TokenAmount::from_atto(sats.into() * SATOSHI_TO_ATTO)
+}
+
 /// Marker type for serialising data to/from string
 pub struct HumanReadable;
 

--- a/ipc/api/src/subnet.rs
+++ b/ipc/api/src/subnet.rs
@@ -6,7 +6,7 @@
 /// to ensure that they are in sync in this project.
 /// However, we should either deprecate the native actors, or make
 /// them use the types from this sdk directly.
-use crate::universal_subnet_id::UniversalSubnetId;
+use crate::subnet_id::SubnetID;
 use fvm_ipld_encoding::repr::*;
 use fvm_shared::{address::Address, clock::ChainEpoch, econ::TokenAmount};
 use serde::{Deserialize, Serialize};
@@ -81,7 +81,7 @@ pub enum ConstructParams {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EthConstructParams {
-    pub parent: UniversalSubnetId,
+    pub parent: SubnetID,
     pub ipc_gateway_addr: Address,
     pub consensus: ConsensusType,
     pub min_validator_stake: TokenAmount,
@@ -97,7 +97,7 @@ pub struct EthConstructParams {
 }
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BtcConstructParams {
-    pub parent: UniversalSubnetId,
+    pub parent: SubnetID,
     pub min_validator_stake: u64,
     pub min_validators: u64,
     pub bottomup_check_period: ChainEpoch,

--- a/ipc/api/src/universal_subnet_id.rs
+++ b/ipc/api/src/universal_subnet_id.rs
@@ -1,4 +1,4 @@
-use fvm_shared::address::Address;
+use fvm_shared::address::{Address, MAX_SUBADDRESS_LEN};
 use lazy_static::lazy_static;
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use ssi_caips::caip2::ChainId;
@@ -88,35 +88,81 @@ impl UniversalSubnetId {
     /// - The root chain ID reference cannot be converted to a u64
     /// - Any child address strings cannot be parsed as Filecoin addresses
     pub fn to_subnet_id(&self) -> Result<SubnetID, Error> {
-        // Check that the namespace is eip155
-        if self.root.namespace != "eip155" {
-            return Err(Error::InvalidID(
+        match self.root.namespace.as_str() {
+            "eip155" => {
+                // Extract the chain ID number from the CAIP-2 chain ID
+                let root_id = self.root.reference.parse::<u64>().map_err(|_| {
+                    Error::InvalidID(
+                        self.to_string(),
+                        "root chain ID reference cannot be converted to u64".into(),
+                    )
+                })?;
+
+                // Convert child strings to Filecoin addresses
+                let mut children = Vec::new();
+                for child in &self.children {
+                    let addr = Address::from_str(child).map_err(|e| {
+                        Error::InvalidID(
+                            self.to_string(),
+                            format!("invalid child address {}: {}", child, e),
+                        )
+                    })?;
+                    children.push(addr);
+                }
+
+                Ok(SubnetID::new(root_id, children))
+            }
+            "bip122" => {
+                // Map known Bitcoin networks to their subnet IDs
+                // TODO update the map and figure out ids
+                let root_id = match self.root.reference.as_str() {
+                    // Bitcoin mainnet genesis block hash
+                    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f" => 1,
+                    // Bitcoin testnet genesis block hash
+                    "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943" => 2,
+                    // Bitcoin testnet genesis block hash
+                    "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206" => 3,
+                    // Add other Bitcoin networks as needed
+                    _ => {
+                        return Err(Error::InvalidID(
+                            self.to_string(),
+                            "unknown Bitcoin network".into(),
+                        ))
+                    }
+                };
+
+                // For Bitcoin subnets, we expect exactly one child for the root subnet
+                if self.children.is_empty() {
+                    return Ok(SubnetID::new_btc(root_id, "")?);
+                }
+
+                // Create Bitcoin subnet with the first child as the Bitcoin address
+                let btc_id = &self.children[0];
+                // Slice to max subaddress length
+                let btc_id = &btc_id[..btc_id.len().min(MAX_SUBADDRESS_LEN)];
+                let mut subnet = SubnetID::new_btc(root_id, btc_id)?;
+
+                // Add any additional children as regular addresses
+                for child in &self.children[1..] {
+                    let addr = Address::from_str(child).map_err(|e| {
+                        Error::InvalidID(
+                            self.to_string(),
+                            format!("invalid child address {}: {}", child, e),
+                        )
+                    })?;
+                    subnet = SubnetID::new_from_parent(&subnet, addr);
+                }
+
+                Ok(subnet)
+            }
+            _ => Err(Error::InvalidID(
                 self.to_string(),
-                "only eip155 namespace can be converted to SubnetID".into(),
-            ));
+                format!(
+                    "namespace {} cannot be converted to SubnetID",
+                    self.root.namespace
+                ),
+            )),
         }
-
-        // Extract the chain ID number from the CAIP-2 chain ID
-        let root_id = self.root.reference.parse::<u64>().map_err(|_| {
-            Error::InvalidID(
-                self.to_string(),
-                "root chain ID reference cannot be converted to u64".into(),
-            )
-        })?;
-
-        // Convert child strings to Filecoin addresses
-        let mut children = Vec::new();
-        for child in &self.children {
-            let addr = Address::from_str(child).map_err(|e| {
-                Error::InvalidID(
-                    self.to_string(),
-                    format!("invalid child address {}: {}", child, e),
-                )
-            })?;
-            children.push(addr);
-        }
-
-        Ok(SubnetID::new(root_id, children))
     }
 
     /// Creates a UniversalSubnetId from an existing SubnetID
@@ -261,6 +307,8 @@ impl FromStr for UniversalSubnetId {
 
 #[cfg(test)]
 mod tests {
+    use crate::subnet_id::NetworkType;
+
     use super::*;
 
     #[test]
@@ -305,7 +353,6 @@ mod tests {
         assert!(UniversalSubnetId::from_str("invalid").is_err());
         assert!(UniversalSubnetId::from_str("").is_err());
         assert!(UniversalSubnetId::from_str("invalid:chain:id").is_err());
-        assert!(UniversalSubnetId::from_str("/eip155").is_err());
     }
 
     #[test]
@@ -340,24 +387,20 @@ mod tests {
     }
 
     #[test]
-    fn test_universal_subnet_id_only_eip155_convertible() {
+    fn test_universal_subnet_id_convertible() {
         // Bitcoin mainnet should fail conversion
         let bitcoin_id_str = "/bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287";
         let bitcoin_universal_id = UniversalSubnetId::from_str(bitcoin_id_str).unwrap();
-        assert!(bitcoin_universal_id.to_subnet_id().is_err());
+        let btc_subnet_id = bitcoin_universal_id.to_subnet_id().expect("should convert");
+        assert_eq!(btc_subnet_id.network_type(), NetworkType::Btc);
+        assert_eq!(btc_subnet_id.root_id(), 1);
 
         // EIP155 should succeed
         let eip155_id_str = "/eip155:1/f01001";
         let eip155_universal_id = UniversalSubnetId::from_str(eip155_id_str).unwrap();
-        assert!(eip155_universal_id.to_subnet_id().is_ok());
-
-        // Verify error message
-        match bitcoin_universal_id.to_subnet_id() {
-            Err(Error::InvalidID(_, msg)) => {
-                assert_eq!(msg, "only eip155 namespace can be converted to SubnetID");
-            }
-            _ => panic!("Expected InvalidID error with namespace message"),
-        }
+        let eip155_subnet_id = eip155_universal_id.to_subnet_id().expect("should convert");
+        assert_eq!(eip155_subnet_id.network_type(), NetworkType::Eip155);
+        assert_eq!(eip155_subnet_id.root_id(), 1);
     }
 
     #[test]

--- a/ipc/cli/src/commands/mod.rs
+++ b/ipc/cli/src/commands/mod.rs
@@ -24,7 +24,6 @@ use ipc_api::ethers_address_to_fil_address;
 
 use fvm_shared::address::set_current_network;
 use ipc_api::subnet_id::SubnetID;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_provider::config::{Config, Subnet};
 use std::fmt::Debug;
 use std::io;
@@ -181,8 +180,6 @@ pub(crate) fn get_subnet_config(
     subnet: &SubnetID,
 ) -> Result<Subnet> {
     let config = Config::from_file(&config_path)?;
-    let subnet = &UniversalSubnetId::from_subnet_id(&subnet);
-
     Ok(config
         .subnets
         .get(subnet)

--- a/ipc/cli/src/commands/subnet/genesis_epoch.rs
+++ b/ipc/cli/src/commands/subnet/genesis_epoch.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 use clap::Args;
-use ipc_api::subnet_id::SubnetID;
+use ipc_api::universal_subnet_id::UniversalSubnetId;
 use std::fmt::Debug;
 use std::str::FromStr;
 
@@ -21,7 +21,7 @@ impl CommandLineHandler for GenesisEpoch {
         log::debug!("get genesis epoch with args: {:?}", arguments);
 
         let provider = get_ipc_provider(global)?;
-        let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let subnet = UniversalSubnetId::from_str(&arguments.subnet)?;
 
         let ls = provider.genesis_epoch(&subnet).await?;
         println!("genesis epoch: {}", ls);

--- a/ipc/cli/src/commands/subnet/genesis_epoch.rs
+++ b/ipc/cli/src/commands/subnet/genesis_epoch.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 use clap::Args;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
+use ipc_api::subnet_id::SubnetID;
 use std::fmt::Debug;
 use std::str::FromStr;
 
@@ -21,7 +21,7 @@ impl CommandLineHandler for GenesisEpoch {
         log::debug!("get genesis epoch with args: {:?}", arguments);
 
         let provider = get_ipc_provider(global)?;
-        let subnet = UniversalSubnetId::from_str(&arguments.subnet)?;
+        let subnet = SubnetID::from_str(&arguments.subnet)?;
 
         let ls = provider.genesis_epoch(&subnet).await?;
         println!("genesis epoch: {}", ls);

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 use clap::Args;
-use ipc_api::{subnet_id::SubnetID, universal_subnet_id::UniversalSubnetId};
+use ipc_api::subnet_id::SubnetID;
 use num_traits::Zero;
 use std::{fmt::Debug, str::FromStr};
 

--- a/ipc/cli/src/commands/subnet/rpc.rs
+++ b/ipc/cli/src/commands/subnet/rpc.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 use clap::Args;
-use ipc_api::{subnet_id::SubnetID, universal_subnet_id::UniversalSubnetId};
+use ipc_api::subnet_id::SubnetID;
 use std::fmt::Debug;
 use std::str::FromStr;
 
@@ -22,8 +22,7 @@ impl CommandLineHandler for RPCSubnet {
 
         let provider = get_ipc_provider(global)?;
         let subnet = SubnetID::from_str(&arguments.network)?;
-        let universal_subnet_id = UniversalSubnetId::from_subnet_id(&subnet);
-        let conn = match provider.connection(&universal_subnet_id) {
+        let conn = match provider.connection(&subnet) {
             None => return Err(anyhow::anyhow!("target subnet not found")),
             Some(conn) => conn,
         };
@@ -53,8 +52,7 @@ impl CommandLineHandler for ChainIdSubnet {
 
         let provider = get_ipc_provider(global)?;
         let subnet = SubnetID::from_str(&arguments.network)?;
-        let universal_subnet_id = UniversalSubnetId::from_subnet_id(&subnet);
-        let conn = match provider.connection(&universal_subnet_id) {
+        let conn = match provider.connection(&subnet) {
             None => return Err(anyhow::anyhow!("target subnet not found")),
             Some(conn) => conn,
         };

--- a/ipc/provider/src/checkpoint.rs
+++ b/ipc/provider/src/checkpoint.rs
@@ -46,11 +46,8 @@ impl<T: BottomUpCheckpointRelayer> BottomUpCheckpointManager<T> {
         child_handler: T,
         max_parallelism: usize,
     ) -> Result<Self> {
-        // TODO use universal subnet id
-        let child_id = &child.id.to_subnet_id()?;
-
         let period = parent_handler
-            .checkpoint_period(child_id)
+            .checkpoint_period(&child.id)
             .await
             .map_err(|e| anyhow!("cannot get bottom up checkpoint period: {e}"))?;
         Ok(Self {
@@ -134,11 +131,9 @@ impl<T: BottomUpCheckpointRelayer + Send + Sync + 'static> BottomUpCheckpointMan
 
     /// Checks if the relayer has already submitted at the next submission epoch, if not it submits it.
     async fn submit_next_epoch(&self, submitter: Address) -> Result<()> {
-        let child_id = &self.metadata.child.id.to_subnet_id()?;
-
         let last_checkpoint_epoch = self
             .parent_handler
-            .last_bottom_up_checkpoint_height(child_id)
+            .last_bottom_up_checkpoint_height(&self.metadata.child.id)
             .await
             .map_err(|e| {
                 anyhow!("cannot obtain the last bottom up checkpoint height due to: {e:}")

--- a/ipc/provider/src/config/deserialize.rs
+++ b/ipc/provider/src/config/deserialize.rs
@@ -7,7 +7,6 @@ use anyhow::anyhow;
 use fvm_shared::address::Address;
 use http::HeaderValue;
 use ipc_api::subnet_id::SubnetID;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_types::EthAddress;
 use serde::de::{Error, SeqAccess};
 use serde::{Deserialize, Deserializer};
@@ -21,7 +20,7 @@ use url::Url;
 /// Subnet struct as value from a vec of subnets
 pub(crate) fn deserialize_subnets_from_vec<'de, D>(
     deserializer: D,
-) -> anyhow::Result<HashMap<UniversalSubnetId, Subnet>, D::Error>
+) -> anyhow::Result<HashMap<SubnetID, Subnet>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -103,31 +102,6 @@ where
             E: Error,
         {
             SubnetID::from_str(v).map_err(E::custom)
-        }
-    }
-    deserializer.deserialize_str(SubnetIDVisitor)
-}
-
-/// A serde deserialization method to deserialize a subnet path string into a [`UniversalSubnetId`].
-pub(crate) fn deserialize_universal_subnet_id<'de, D>(
-    deserializer: D,
-) -> anyhow::Result<UniversalSubnetId, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct SubnetIDVisitor;
-    impl<'de> serde::de::Visitor<'de> for SubnetIDVisitor {
-        type Value = UniversalSubnetId;
-
-        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-            formatter.write_str("a string")
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            UniversalSubnetId::from_str(v).map_err(E::custom)
         }
     }
     deserializer.deserialize_str(SubnetIDVisitor)

--- a/ipc/provider/src/config/mod.rs
+++ b/ipc/provider/src/config/mod.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use deserialize::deserialize_subnets_from_vec;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
+use ipc_api::subnet_id::SubnetID;
 use serde::{Deserialize, Serialize};
 use serialize::serialize_subnets_to_str;
 pub use subnet::Subnet;
@@ -31,7 +31,7 @@ keystore_path = "~/.ipc"
 
 # Filecoin Calibration
 [[subnets]]
-id = "/eip155:314159"
+id = "/r314159"
 
 [subnets.config]
 network_type = "fevm"
@@ -41,7 +41,7 @@ registry_addr = "0x0b4e239FF21b40120cDa817fba77bD1B366c1bcD"
 
 # Subnet template - uncomment and adjust before using
 # [[subnets]]
-# id = "/eip155:314159/<SUBNET_ID>"
+# id = "/r314159/<SUBNET_ID>"
 
 # [subnets.config]
 # network_type = "fevm"
@@ -58,7 +58,7 @@ pub struct Config {
     pub keystore_path: Option<String>,
     #[serde(deserialize_with = "deserialize_subnets_from_vec", default)]
     #[serde(serialize_with = "serialize_subnets_to_str")]
-    pub subnets: HashMap<UniversalSubnetId, Subnet>,
+    pub subnets: HashMap<SubnetID, Subnet>,
 }
 
 impl Config {
@@ -107,7 +107,7 @@ impl Config {
         self.subnets.insert(subnet.id.clone(), subnet);
     }
 
-    pub fn remove_subnet(&mut self, subnet_id: &UniversalSubnetId) {
+    pub fn remove_subnet(&mut self, subnet_id: &SubnetID) {
         self.subnets.remove(subnet_id);
     }
 }

--- a/ipc/provider/src/config/serialize.rs
+++ b/ipc/provider/src/config/serialize.rs
@@ -6,7 +6,6 @@ use crate::config::Subnet;
 use anyhow::anyhow;
 use fvm_shared::address::{Address, Payload};
 use ipc_api::subnet_id::SubnetID;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_types::EthAddress;
 use serde::ser::{Error, SerializeSeq};
 use serde::Serializer;
@@ -15,7 +14,7 @@ use std::collections::HashMap;
 /// A serde serialization method to serialize a hashmap of subnets with subnet id as key and
 /// Subnet struct as value to a vec of subnets
 pub fn serialize_subnets_to_str<S>(
-    subnets: &HashMap<UniversalSubnetId, Subnet>,
+    subnets: &HashMap<SubnetID, Subnet>,
     s: S,
 ) -> Result<S::Ok, S::Error>
 where
@@ -31,16 +30,6 @@ where
 }
 
 pub fn serialize_subnet_id_to_str<S>(id: &SubnetID, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    s.serialize_str(&id.to_string())
-}
-
-pub fn serialize_universal_subnet_id_to_str<S>(
-    id: &UniversalSubnetId,
-    s: S,
-) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/ipc/provider/src/config/subnet.rs
+++ b/ipc/provider/src/config/subnet.rs
@@ -4,24 +4,24 @@ use std::time::Duration;
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: MIT
 use fvm_shared::address::Address;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
+use ipc_api::subnet_id::SubnetID;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
 use url::Url;
 
 use crate::config::deserialize::{
-    deserialize_address_from_str, deserialize_eth_address_from_str, deserialize_universal_subnet_id,
+    deserialize_address_from_str, deserialize_eth_address_from_str, deserialize_subnet_id,
 };
 use crate::config::serialize::{
-    serialize_address_to_str, serialize_eth_address_to_str, serialize_universal_subnet_id_to_str,
+    serialize_address_to_str, serialize_eth_address_to_str, serialize_subnet_id_to_str,
 };
 
 /// Represents a subnet declaration in the config.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Subnet {
-    #[serde(deserialize_with = "deserialize_universal_subnet_id")]
-    #[serde(serialize_with = "serialize_universal_subnet_id_to_str")]
-    pub id: UniversalSubnetId,
+    #[serde(deserialize_with = "deserialize_subnet_id")]
+    #[serde(serialize_with = "serialize_subnet_id_to_str")]
+    pub id: SubnetID,
     pub config: SubnetConfig,
 }
 

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -591,9 +591,9 @@ impl IpcProvider {
     }
 
     /// Obtain the genesis epoch of the input subnet.
-    pub async fn genesis_epoch(&self, subnet: &SubnetID) -> anyhow::Result<ChainEpoch> {
+    pub async fn genesis_epoch(&self, subnet: &UniversalSubnetId) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = self.get_connection_legacy(&parent)?;
+        let conn = self.get_connection(&parent)?;
         conn.manager().genesis_epoch(subnet).await
     }
 

--- a/ipc/provider/src/lotus/client.rs
+++ b/ipc/provider/src/lotus/client.rs
@@ -450,22 +450,7 @@ impl LotusJsonRPCClient<JsonRpcClientImpl> {
         let url = subnet.rpc_http().clone();
         let auth_token = subnet.auth_token();
         let jsonrpc_client = JsonRpcClientImpl::new(url, auth_token.as_deref());
-
-        // TODO use universal subnet id
-        let subnet_id = match subnet.id.to_subnet_id() {
-            Ok(subnet_id) => subnet_id,
-            Err(e) => {
-                tracing::error!(
-                    "lotus from_subnet: failed to convert subnet id to subnet id: {:?}",
-                    e
-                );
-                panic!(
-                    "lotus from_subnet: failed to convert subnet id to subnet id: {:?}",
-                    e
-                );
-            }
-        };
-        LotusJsonRPCClient::new(jsonrpc_client, subnet_id)
+        LotusJsonRPCClient::new(jsonrpc_client, subnet.id.clone())
     }
 
     pub fn from_subnet_with_wallet_store(
@@ -475,17 +460,7 @@ impl LotusJsonRPCClient<JsonRpcClientImpl> {
         let url = subnet.rpc_http().clone();
         let auth_token = subnet.auth_token();
         let jsonrpc_client = JsonRpcClientImpl::new(url, auth_token.as_deref());
-
-        // TODO use universal subnet id
-        let subnet_id = match subnet.id.to_subnet_id() {
-            Ok(subnet_id) => subnet_id,
-            Err(e) => {
-                tracing::error!("lotus from_subnet_with_wallet_store: failed to convert subnet id to subnet id: {:?}", e);
-                panic!("lotus from_subnet_with_wallet_store: failed to convert subnet id to subnet id: {:?}", e);
-            }
-        };
-
-        LotusJsonRPCClient::new_with_wallet_store(jsonrpc_client, subnet_id, wallet_store)
+        LotusJsonRPCClient::new_with_wallet_store(jsonrpc_client, subnet.id.clone(), wallet_store)
     }
 }
 

--- a/ipc/provider/src/manager/btc/manager.rs
+++ b/ipc/provider/src/manager/btc/manager.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use ethers::providers::Authorization;
 use http::HeaderValue;
 use ipc_api::subnet::{Asset, AssetKind, BtcConstructParams, ConstructParams, PermissionMode};
-use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_api::validator::Validator;
 use ipc_api::{ethers_address_to_fil_address, token_amount_from_satoshi};
 use reqwest::Client;
@@ -80,7 +79,7 @@ impl BtcSubnetManager {
 }
 #[async_trait]
 impl SubnetManager for BtcSubnetManager {
-    async fn create_subnet(&self, _from: Address, params: ConstructParams) -> Result<String> {
+    async fn create_subnet(&self, _from: Address, params: ConstructParams) -> Result<Address> {
         let params: BtcConstructParams = match params {
             ConstructParams::Eth(_) => return Err(anyhow!("Unsupported subnet configuration")),
             ConstructParams::Btc(params) => params,
@@ -147,7 +146,7 @@ impl SubnetManager for BtcSubnetManager {
 
         tracing::info!("New subnet created with ID: {subnet_id}");
 
-        let subnet_id = UniversalSubnetId::from_str(subnet_id)?;
+        let subnet_id = SubnetID::from_str(subnet_id)?;
         let new_child = subnet_id
             .children_as_ref()
             .last()
@@ -310,7 +309,7 @@ impl SubnetManager for BtcSubnetManager {
         todo!()
     }
 
-    async fn get_genesis_info(&self, subnet_id: &UniversalSubnetId) -> Result<SubnetGenesisInfo> {
+    async fn get_genesis_info(&self, subnet_id: &SubnetID) -> Result<SubnetGenesisInfo> {
         tracing::info!("getting genesis info on btc with params: {subnet_id:?}");
 
         let body = json!({
@@ -558,7 +557,7 @@ impl BottomUpCheckpointRelayer for BtcSubnetManager {
 #[async_trait]
 impl TopDownFinalityQuery for BtcSubnetManager {
     /// Returns the genesis epoch that the subnet is created in parent network
-    async fn genesis_epoch(&self, subnet_id: &UniversalSubnetId) -> Result<ChainEpoch> {
+    async fn genesis_epoch(&self, subnet_id: &SubnetID) -> Result<ChainEpoch> {
         tracing::info!("getting genesis epoch on btc for: {subnet_id}");
 
         let body = json!({

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -14,7 +14,6 @@ use ipc_actors_abis::{
     subnet_actor_manager_facet, subnet_actor_reward_facet,
 };
 use ipc_api::evm::{fil_to_eth_amount, payload_to_evm_address, subnet_id_to_evm_addresses};
-use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_api::validator::from_contract_validators;
 use reqwest::header::HeaderValue;
 use reqwest::Client;
@@ -105,8 +104,7 @@ abigen!(
 
 #[async_trait]
 impl TopDownFinalityQuery for EthSubnetManager {
-    async fn genesis_epoch(&self, subnet_id: &UniversalSubnetId) -> Result<ChainEpoch> {
-        let subnet_id = &subnet_id.to_subnet_id()?;
+    async fn genesis_epoch(&self, subnet_id: &SubnetID) -> Result<ChainEpoch> {
         let address = contract_address_from_subnet(subnet_id)?;
         tracing::info!("querying genesis epoch in evm subnet contract: {address:}");
 
@@ -257,7 +255,7 @@ impl TopDownFinalityQuery for EthSubnetManager {
 
 #[async_trait]
 impl SubnetManager for EthSubnetManager {
-    async fn create_subnet(&self, from: Address, params: ConstructParams) -> Result<String> {
+    async fn create_subnet(&self, from: Address, params: ConstructParams) -> Result<Address> {
         let params: EthConstructParams = match params {
             ConstructParams::Eth(params) => params,
             ConstructParams::Btc(_) => return Err(anyhow!("Unsupported subnet configuration")),
@@ -272,13 +270,12 @@ impl SubnetManager for EthSubnetManager {
 
         tracing::debug!("calling create subnet for EVM manager");
 
-        let parent = params.parent.to_subnet_id()?;
-        let route = subnet_id_to_evm_addresses(&parent)?;
+        let route = subnet_id_to_evm_addresses(&params.parent)?;
         tracing::debug!("root SubnetID as Ethereum type: {route:?}");
 
         let params = register_subnet_facet::ConstructorParams {
             parent_id: register_subnet_facet::SubnetID {
-                root: parent.root_id(),
+                root: params.parent.root_id(),
                 route,
             },
             ipc_gateway_addr: self.ipc_contract_info.gateway_addr,
@@ -326,8 +323,7 @@ impl SubnetManager for EthSubnetManager {
                                 subnet_deploy;
 
                             tracing::debug!("subnet deployed at {subnet_addr:?}");
-                            let addr = ethers_address_to_fil_address(&subnet_addr)?;
-                            return Ok(addr.to_string());
+                            return ethers_address_to_fil_address(&subnet_addr);
                         }
                         Err(_) => {
                             tracing::debug!("no event for subnet actor published yet, continue");
@@ -796,12 +792,7 @@ impl SubnetManager for EthSubnetManager {
         Ok(Asset::try_from(raw)?)
     }
 
-    async fn get_genesis_info(
-        &self,
-        universal_subnet_id: &UniversalSubnetId,
-    ) -> Result<SubnetGenesisInfo> {
-        let subnet = &universal_subnet_id.to_subnet_id()?;
-
+    async fn get_genesis_info(&self, subnet: &SubnetID) -> Result<SubnetGenesisInfo> {
         let address = contract_address_from_subnet(subnet)?;
         let contract = subnet_actor_getter_facet::SubnetActorGetterFacet::new(
             address,
@@ -817,7 +808,7 @@ impl SubnetManager for EthSubnetManager {
             // Bottom-up checkpoint period set in the subnet actor.
             bottom_up_checkpoint_period,
             // Genesis epoch when the subnet was bootstrapped in the parent.
-            genesis_epoch: self.genesis_epoch(universal_subnet_id).await?,
+            genesis_epoch: self.genesis_epoch(subnet).await?,
             // Majority percentage of
             majority_percentage: contract.majority_percentage().call().await?,
             // Minimum collateral required for subnets to register into the subnet
@@ -1202,12 +1193,10 @@ impl EthSubnetManager {
         let gateway_address = payload_to_evm_address(config.gateway_addr.payload())?;
         let registry_address = payload_to_evm_address(config.registry_addr.payload())?;
 
-        let subnet_id = subnet.id.to_subnet_id()?;
-
         Ok(Self::new(
             gateway_address,
             registry_address,
-            subnet_id.chain_id(),
+            subnet.id.chain_id(),
             provider,
             keystore,
         ))

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -237,7 +237,7 @@ pub struct GetBlockHashResult {
 #[async_trait]
 pub trait TopDownFinalityQuery: Send + Sync {
     /// Returns the genesis epoch that the subnet is created in parent network
-    async fn genesis_epoch(&self, subnet_id: &SubnetID) -> Result<ChainEpoch>;
+    async fn genesis_epoch(&self, subnet_id: &UniversalSubnetId) -> Result<ChainEpoch>;
     /// Returns the chain head height
     async fn chain_head_height(&self) -> Result<ChainEpoch>;
     /// Returns the list of top down messages

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -14,7 +14,6 @@ use ipc_api::cross::IpcEnvelope;
 use ipc_api::staking::{StakingChangeRequest, ValidatorInfo};
 use ipc_api::subnet::{Asset, ConstructParams, PermissionMode};
 use ipc_api::subnet_id::SubnetID;
-use ipc_api::universal_subnet_id::UniversalSubnetId;
 use ipc_api::validator::Validator;
 use std::collections::{BTreeMap, HashMap};
 
@@ -29,7 +28,7 @@ pub trait SubnetManager:
     /// configuration passed in `ConstructParams`.
     /// The result of the function is the ID of the subnet child from which the final
     /// subnet ID can be inferred.
-    async fn create_subnet(&self, from: Address, params: ConstructParams) -> Result<String>;
+    async fn create_subnet(&self, from: Address, params: ConstructParams) -> Result<Address>;
 
     /// Performs the call to join a subnet from a wallet address and staking an amount
     /// of collateral. This function, as well as all of the ones on this trait, can infer
@@ -173,7 +172,7 @@ pub trait SubnetManager:
     async fn get_subnet_collateral_source(&self, subnet: &SubnetID) -> Result<Asset>;
 
     /// Gets the genesis information required to bootstrap a child subnet
-    async fn get_genesis_info(&self, subnet: &UniversalSubnetId) -> Result<SubnetGenesisInfo>;
+    async fn get_genesis_info(&self, subnet: &SubnetID) -> Result<SubnetGenesisInfo>;
 
     /// Advertises the endpoint of a bootstrap node for the subnet.
     async fn add_bootstrap(
@@ -237,7 +236,7 @@ pub struct GetBlockHashResult {
 #[async_trait]
 pub trait TopDownFinalityQuery: Send + Sync {
     /// Returns the genesis epoch that the subnet is created in parent network
-    async fn genesis_epoch(&self, subnet_id: &UniversalSubnetId) -> Result<ChainEpoch>;
+    async fn genesis_epoch(&self, subnet_id: &SubnetID) -> Result<ChainEpoch>;
     /// Returns the chain head height
     async fn chain_head_height(&self) -> Result<ChainEpoch>;
     /// Returns the list of top down messages


### PR DESCRIPTION
Implements `get_genesis_info` and `genesis_epoch` in the Bitcoin subnet manager, needed for creating a genesis file when running the Fendermint nodes.
 
 One big change is another iteration on the subnet id changes, SubnetID now supports bitcoin (in a backwards compatible way) due to big complexities to replace the current subnet id struct with the new universal subnet id.

There's some refactoring needed in the btc subnet manager, regarding the requests, but this'll be done in a follow-up PR.

Currently topdown messages are disabled in Fendermint as this is still not supported.

Closes #12 
Progress for https://github.com/bitcoinscalinglabs/bitcoin-ipc/issues/60