### PR TITLE
feat: collect signatures for bootstrap handover, read the and submit the handover

### DIFF
--- a/contracts/contracts/gateway/router/CheckpointingFacet.sol
+++ b/contracts/contracts/gateway/router/CheckpointingFacet.sol
@@ -6,7 +6,7 @@ import {BottomUpCheckpoint} from "../../structs/CrossNet.sol";
 import {LibGateway} from "../../lib/LibGateway.sol";
 import {LibQuorum} from "../../lib/LibQuorum.sol";
 import {Subnet} from "../../structs/Subnet.sol";
-import {BitcoinCheckpoint} from "../../structs/Bitcoin.sol";
+import {BitcoinCheckpoint, BitcoinBootstrapHandover} from "../../structs/Bitcoin.sol";
 import {QuorumObjKind} from "../../structs/Quorum.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
@@ -23,6 +23,7 @@ import {ActivityRollupRecorded, FullActivityRollup} from "../../structs/Activity
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 event BitcoinCheckpointAdded(uint256 indexed height, address indexed signatory, bytes32 indexed psbtHash);
+event BitcoinBootstrapHandoverAdded(address indexed signatory, bytes32 indexed psbtHash);
 
 contract CheckpointingFacet is GatewayActorModifiers {
     using SubnetIDHelper for SubnetID;
@@ -267,6 +268,106 @@ contract CheckpointingFacet is GatewayActorModifiers {
         }
 
         return (psbt, batchTransferTx, signatories, signatures);
+    }
+
+    function addBitcoinBootstrapHandoverSignature(
+        bytes calldata psbt,
+        bytes calldata signatures
+    ) external {
+
+        address signatory = msg.sender;
+        bytes32 psbtHash = keccak256(psbt);
+
+        // Check if this is a new PSBT hash
+        bool hashExists = false;
+        for (uint i = 0; i < s.bitcoinBootstrapHandoverPsbtHashes.length; i++) {
+            if (s.bitcoinBootstrapHandoverPsbtHashes[i] == psbtHash) {
+                hashExists = true;
+                break;
+            }
+        }
+        if (!hashExists) {
+            s.bitcoinBootstrapHandoverPsbtHashes.push(psbtHash);
+        }
+
+        BitcoinBootstrapHandover storage btcHandover = s.bitcoinBootstrapHandovers[psbtHash];
+        // Set the PSBT if it hasn't been set yet
+        if (btcHandover.psbt.length == 0) {
+            btcHandover.psbt = psbt;
+        }
+
+        // Check if sender is already a signatory
+        bool alreadySigned = false;
+        for (uint i = 0; i < btcHandover.signatories.length; i++) {
+            if (btcHandover.signatories[i] == signatory) {
+                alreadySigned = true;
+                break;
+            }
+        }
+
+        // Add the signature to the Bitcoin handover transaction if not already a signatory
+        if (alreadySigned) {
+            revert SignatureReplay();
+        } else {
+            btcHandover.signatories.push(signatory);
+            btcHandover.signatures[signatory] = signatures;
+            emit BitcoinBootstrapHandoverAdded(signatory, keccak256(psbt));
+        }
+    }
+
+    /// @notice Get the Bitcoin bootstrap handover with the most signatures.
+    /// @return psbt - The base64 of the PSBT with the most signatures.
+    /// @return signatories - The list of validators who signed.
+    /// @return signatures - The list of signatures corresponding to the signatories.
+    function getBitcoinBootstrapHandoverSignatures(
+    )
+        external
+        view
+        returns (
+            bytes memory psbt,
+            address[] memory signatories,
+            bytes[] memory signatures
+        )
+    {
+        bytes32[] storage hashes = s.bitcoinBootstrapHandoverPsbtHashes;
+        if (hashes.length == 0) {
+            // No Bitcoin handovers found
+            return (new bytes(0), new address[](0), new bytes[](0));
+        }
+
+        // Find the checkpoint with the most signatures
+        bytes32 mostSignedPsbtHash;
+        uint256 maxSignatures = 0;
+
+        for (uint256 i = 0; i < hashes.length; i++) {
+            bytes32 currentHash = hashes[i];
+            BitcoinBootstrapHandover storage currentHandover = s.bitcoinBootstrapHandovers[currentHash];
+
+            uint256 signatureCount = currentHandover.signatories.length;
+
+            // When multiple PSBTs have the same number of signatures, keep the first
+            if (signatureCount > maxSignatures) {
+                maxSignatures = signatureCount;
+                mostSignedPsbtHash = currentHash;
+            }
+        }
+
+        // Get the handover with the most signatures
+        BitcoinBootstrapHandover storage btcHandover = s.bitcoinBootstrapHandovers[mostSignedPsbtHash];
+
+        // Return the PSBT
+        psbt = btcHandover.psbt;
+
+        // Return signatories
+        signatories = btcHandover.signatories;
+
+        // Map signatories to their signatures
+        signatures = new bytes[](signatories.length);
+        for (uint256 i = 0; i < signatories.length; i++) {
+            signatures[i] = btcHandover.signatures[signatories[i]];
+        }
+
+        return (psbt, signatories, signatures);
     }
 
     /// @notice submit a batch of cross-net messages for execution.

--- a/contracts/contracts/lib/LibGatewayActorStorage.sol
+++ b/contracts/contracts/lib/LibGatewayActorStorage.sol
@@ -6,7 +6,7 @@ import {QuorumMap} from "../structs/Quorum.sol";
 import {BottomUpCheckpoint, BottomUpMsgBatch, IpcEnvelope, ParentFinality} from "../structs/CrossNet.sol";
 import {SubnetID, Subnet, ParentValidatorsTracker} from "../structs/Subnet.sol";
 import {Membership} from "../structs/Subnet.sol";
-import {BitcoinCheckpoint} from "../structs/Bitcoin.sol";
+import {BitcoinCheckpoint, BitcoinBootstrapHandover} from "../structs/Bitcoin.sol";
 import {AccountHelper} from "../lib/AccountHelper.sol";
 import {FilAddress} from "fevmate/contracts/utils/FilAddress.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
@@ -77,6 +77,8 @@ struct GatewayActorStorage {
     // =========== Bitcoin ===========
     mapping(uint256 => mapping(bytes32 => BitcoinCheckpoint)) bitcoinCheckpoints;
     mapping(uint256 => bytes32[]) bitcoinCheckpointPsbtHashes;
+    mapping(bytes32 => BitcoinBootstrapHandover) bitcoinBootstrapHandovers;
+    bytes32[] bitcoinBootstrapHandoverPsbtHashes;
 }
 
 library LibGatewayActorStorage {

--- a/contracts/contracts/structs/Bitcoin.sol
+++ b/contracts/contracts/structs/Bitcoin.sol
@@ -11,3 +11,12 @@ struct BitcoinCheckpoint {
     /// @dev The list of signatures.
     mapping(address => bytes) signatures;
 }
+
+struct BitcoinBootstrapHandover {
+    /// @dev The base64 of the psbt.
+    bytes psbt;
+    /// @dev The list of validators who signed.
+    address[] signatories;
+    /// @dev The list of signatures.
+    mapping(address => bytes) signatures;
+}

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -409,6 +409,58 @@ where
     Ok(())
 }
 
+pub async fn broadcast_bitcoin_signature_for_bootstrap_handover<C, DB>(
+    broadcaster: &Broadcaster<C>,
+    gateway: &GatewayCaller<DB>,
+    subnet_id: Option<ipc_api::subnet_id::SubnetID>,
+    parent_manager: Option<ipc_provider::manager::BtcSubnetManager>,
+    chain_id: ChainID,
+) -> anyhow::Result<()>
+where
+    C: Client + Clone + Send + Sync + 'static,
+    DB: Blockstore + Send + Sync + Clone + 'static,
+{
+    let subnet_id = match &subnet_id {
+        Some(subnet_id) => subnet_id,
+        None => {
+            return Err(anyhow!(
+                "broadcast_bitcoin_signature_for_bootstrap_handover needs the subnet_id of the current subnet"
+            ))
+        }
+    };
+    let parent_manager = match &parent_manager {
+        Some(parent_manager) => parent_manager,
+        None => {
+            return Err(anyhow!(
+                "broadcast_bitcoin_signature_for_bootstrap_handover needs the parent manager"
+            ))
+        }
+    };
+
+    let bootstrap_handover_psbt = parent_manager
+        .get_bootstrap_handover_transaction(subnet_id)
+        .await?;
+    tracing::info!(
+        "interpreter obtained bootstrap-handover PSBT from bitcoin provider: {bootstrap_handover_psbt:?}"
+    );
+
+    let calldata = gateway
+        .add_bitcoin_bootstrap_handover_signature_calldata(bootstrap_handover_psbt)
+        .context("failed to produce bitcoin bootstrap-handover signature calldata")?;
+
+    let tx_hash = broadcaster
+        .fevm_invoke(Address::from(gateway.addr()), calldata, chain_id)
+        .await
+        .context("failed to broadcast bitcoin bootstrap-handover signature")?;
+
+    tracing::info!(
+        tx_hash = tx_hash.to_string(),
+        "broadcasted bitcoin bootstrap-handover signature"
+    );
+
+    Ok(())
+}
+
 /// As a validator, sign the checkpoint and broadcast a transaction to add our signature to the ledger.
 pub async fn broadcast_signature<C, DB>(
     broadcaster: &Broadcaster<C>,

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -220,6 +220,43 @@ where
                 });
             });
 
+        let height = state.block_height();
+
+        // When the subnet starts, we need to broadcast the bootstrap-handover signature
+        // TODO(bitcoin):
+        // We are also not checking whether the validator has a positive voting power,
+        // probably not needed, but the code for checkpoint signatures does it.
+        if height == 10 {
+            if let Some(ref ctx) = self.validator_ctx {
+                if !self.syncing().await {
+                    let validator_ctx = ctx.clone();
+                    let gateway = self.gateway.clone();
+                    let subnet_id = self.subnet_id.clone();
+                    let parent_manager = self.parent_manager.clone();
+                    let chain_id = state.chain_id();
+
+                    tokio::spawn(async move {
+                        let res = checkpoint::broadcast_bitcoin_signature_for_bootstrap_handover(
+                            &validator_ctx.broadcaster,
+                            &gateway,
+                            subnet_id,
+                            parent_manager,
+                            chain_id,
+                        )
+                        .await;
+
+                        if let Err(e) = res {
+                            tracing::error!(error =? e, "error broadcasting bootstrap-handover signature");
+                        } else {
+                            tracing::info!(
+                                "broadcasted bootstrap-handover signature at height {height:?}"
+                            );
+                        }
+                    });
+                }
+            }
+        }
+
         let updates = if let Some((checkpoint, updates)) =
             checkpoint::maybe_create_checkpoint(&self.gateway, &mut state, &mut block_end_events)
                 .context("failed to create checkpoint")?

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -235,7 +235,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
     pub fn add_bitcoin_checkpoint_signature_calldata(
         &self,
         checkpoint: &checkpointing_facet::BottomUpCheckpoint,
-        checkpoint_psbt: ipc_api::checkpoint::PsbtSignature,
+        checkpoint_psbt: ipc_api::checkpoint::BitcoinCheckpointSignature,
     ) -> anyhow::Result<et::Bytes> {
         let unsigned_psbt = checkpoint_psbt.unsigned_psbt.clone().decode()?;
         let transfer_tx = checkpoint_psbt.transfer_tx.clone().decode()?;
@@ -261,6 +261,33 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
         let calldata = call
             .calldata()
             .ok_or_else(|| anyhow!("no calldata for adding bitcoin signature"))?;
+
+        Ok(calldata)
+    }
+
+    pub fn add_bitcoin_bootstrap_handover_signature_calldata(
+        &self,
+        handover_psbt: ipc_api::checkpoint::BitcoinHandoverSignature,
+    ) -> anyhow::Result<et::Bytes> {
+        let unsigned_psbt = handover_psbt.unsigned_psbt.clone().decode()?;
+
+        tracing::debug!(
+            "Encoded arguments to add_bitcoin_bootstrap_handover_signature(): {:?}, {:?}",
+            handover_psbt.unsigned_psbt.0,
+            hex::encode(handover_psbt.signature.clone()),
+        );
+
+        let call = self
+            .checkpointing
+            .contract()
+            .add_bitcoin_bootstrap_handover_signature(
+                et::Bytes::from(unsigned_psbt),
+                et::Bytes::from(handover_psbt.signature.clone()),
+            );
+
+        let calldata = call.calldata().ok_or_else(|| {
+            anyhow!("no calldata for adding bitcoin bootstrap-handover signature")
+        })?;
 
         Ok(calldata)
     }

--- a/ipc/api/src/checkpoint.rs
+++ b/ipc/api/src/checkpoint.rs
@@ -64,12 +64,12 @@ pub struct BottomUpCheckpointBundle {
     /// The list of addresses that have signed the checkpoint hash
     pub signatories: Vec<Address>,
     /// The bitcoin data for the checkpoint
-    pub bitcoin_signatures: Option<PsbtSignatureQuorum>,
+    pub bitcoin_signatures: Option<BitcoinCheckpointSignatureQuorum>,
 }
 
-/// A Partially Signed Bitcoin Transaction (PSBT) and a set of signatures
+/// A set of signatures on a bitcoin transaction that encodes a checkpoint.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PsbtSignatureQuorum {
+pub struct BitcoinCheckpointSignatureQuorum {
     /// The unsigned PSBT
     pub unsigned_psbt: UnsignedPsbt,
     /// The signatories
@@ -81,15 +81,36 @@ pub struct PsbtSignatureQuorum {
     pub transfer_tx: BitcoinTx,
 }
 
-/// A Partially Signed Bitcoin Transaction (PSBT) with a single signature
+/// A signature from a single signatory on the bitcoin transaction that encodes a checkpoint.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PsbtSignature {
-    /// The unsigned PSBT
+pub struct BitcoinCheckpointSignature {
+    /// The unsigned PSBT of the checkpoint transaction
     pub unsigned_psbt: UnsignedPsbt,
     /// The signature of a single signatory.
     pub signature: BitcoinSignature,
-    /// The transfer transaction
+    /// The corresponding transfer transaction
     pub transfer_tx: BitcoinTx,
+}
+
+/// A set of signatures on a bitcoin transaction that encodes a bootstrap handover.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BitcoinHandoverSignatureQuorum {
+    /// The unsigned PSBT
+    pub unsigned_psbt: UnsignedPsbt,
+    /// The signatories
+    pub signatories: Vec<ethers::types::Address>,
+    /// The signatures of each signatory.
+    /// `signatures[i]` contains the signature of `signatories[i]`.
+    pub signatures: Vec<BitcoinSignature>,
+}
+
+/// A signature from a single signatory on the bitcoin transaction that encodes a bootstrap handover.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BitcoinHandoverSignature {
+    /// The unsigned PSBT of the bootstrap handover transaction
+    pub unsigned_psbt: UnsignedPsbt,
+    /// The signature of a single signatory.
+    pub signature: BitcoinSignature,
 }
 
 /// A base64-encoded unsigned PSBT

--- a/ipc/provider/src/checkpoint.rs
+++ b/ipc/provider/src/checkpoint.rs
@@ -152,12 +152,55 @@ impl BottomUpCheckpointManager {
     pub async fn run(self, submitter: Option<Address>, submission_interval: Duration) {
         tracing::info!("launching {self} for {submitter:?}");
 
+        // Bootstrap handover must be submitted before the first checkpoint.
+        loop {
+            match self.submit_bootstrap_handover().await {
+                Ok(()) => {
+                    tracing::info!("submitted bootstrap handover");
+                    break;
+                }
+                Err(e) => {
+                    tracing::error!("cannot submit bootstrap handover due to: {e}");
+                }
+            }
+            tokio::time::sleep(submission_interval).await;
+        }
+
         loop {
             if let Err(e) = self.submit_next_epoch(submitter).await {
                 tracing::error!("cannot submit checkpoint due to: {e}");
             }
             tokio::time::sleep(submission_interval).await;
         }
+    }
+
+    async fn submit_bootstrap_handover(&self) -> Result<()> {
+        let current_height = self.child_handler.current_epoch().await?;
+
+        let handover_signatures = self
+            .child_handler
+            .get_bootstrap_handover_signatures(current_height)
+            .await?;
+
+        tracing::info!("handover signatures: {handover_signatures:?}");
+
+        let epoch = self
+            .parent_handler
+            .submit_bootstrap_handover(
+                &self.metadata.child.id,
+                self.keystore.clone(),
+                handover_signatures,
+            )
+            .await
+            .map_err(|e| {
+                anyhow!(
+                    "cannot submit bootstrap handover at height {} due to: {e}",
+                    current_height
+                )
+            })?;
+
+        tracing::info!("submitted bootstrap handover at height {}", epoch);
+        Ok(())
     }
 
     /// Checks if the relayer has already submitted at the next submission epoch, if not it submits it.

--- a/ipc/provider/src/checkpoint.rs
+++ b/ipc/provider/src/checkpoint.rs
@@ -153,6 +153,7 @@ impl BottomUpCheckpointManager {
         tracing::info!("launching {self} for {submitter:?}");
 
         // Bootstrap handover must be submitted before the first checkpoint.
+        let mut boostrap_handover_retries = 3;
         loop {
             match self.submit_bootstrap_handover().await {
                 Ok(()) => {
@@ -161,6 +162,11 @@ impl BottomUpCheckpointManager {
                 }
                 Err(e) => {
                     tracing::error!("cannot submit bootstrap handover due to: {e}");
+                    boostrap_handover_retries -= 1;
+                    if boostrap_handover_retries == 0 {
+                        tracing::error!("failed to submit bootstrap handover after 3 retries");
+                        break;
+                    }
                 }
             }
             tokio::time::sleep(submission_interval).await;

--- a/ipc/provider/src/manager/btc/manager.rs
+++ b/ipc/provider/src/manager/btc/manager.rs
@@ -12,7 +12,10 @@ use ethers::providers::Authorization;
 use ethers::types::H256;
 use http::HeaderValue;
 use ipc_api::address::IPCAddress;
-use ipc_api::checkpoint::{BitcoinTx, PsbtSignature, PsbtSignatureQuorum, UnsignedPsbt};
+use ipc_api::checkpoint::{
+    BitcoinCheckpointSignature, BitcoinCheckpointSignatureQuorum, BitcoinHandoverSignature,
+    BitcoinSignature, BitcoinTx, UnsignedPsbt,
+};
 use ipc_api::evm::payload_to_evm_address;
 use ipc_api::subnet::{
     Asset, AssetKind, BtcConstructParams, BtcFundParams, ConstructParams, FundParams,
@@ -854,7 +857,7 @@ impl SubnetManager for BtcSubnetManager {
         &self,
         subnet_id: &SubnetID,
         checkpoint: BottomUpCheckpoint,
-    ) -> Result<PsbtSignature> {
+    ) -> Result<BitcoinCheckpointSignature> {
         tracing::debug!("Creating bitcoin signatures for checkpoint: {checkpoint:?}");
 
         // collect all withdrawals and transfers from the checkpoint msgs
@@ -953,19 +956,19 @@ impl SubnetManager for BtcSubnetManager {
         // The RPC call returns one signature for each input in the PSBT, hex encoded.
         // We decode each signature and flatten the result into a single vector of bytes,
         // which we then store in the `PsbtSignature` struct.
-        // When these signatures are submitted to the `finalize_checkpoint_psbt` RPC call,
-        // they must be split again (see `submit_checkpoint` of `BtcSubnetManager`).
+        // When these signatures are submitted to the `finalizecheckpointpsbt` RPC call,
+        // they must be split again (see `split_signatures_and_zip_with_signatories`).
         let signature = data
             .get("result")
             .and_then(|r| r.get("psbt_inputs_signatures"))
             .and_then(Value::as_array)
-            .ok_or_else(|| anyhow!("Missing 'result.psbt_inputs_signatures' in JSON-RPC response"))?
+            .ok_or_else(|| anyhow!("Missing 'result.psbt_inputs_signatures' in JSON-RPC response for checkpoint"))?
             .iter()
             .map(|v| {
                 v.as_str()
                     .ok_or_else(|| {
                         anyhow!(
-                            "Invalid entry in 'result.psbt_inputs_signatures' in JSON-RPC response"
+                            "Invalid entry in 'result.psbt_inputs_signatures' in JSON-RPC response for checkpoint"
                         )
                     })
                     .and_then(|s| {
@@ -992,10 +995,110 @@ impl SubnetManager for BtcSubnetManager {
 
         tracing::info!("BtcSubnetManager obtained checkpoint PSBT and signatures.");
 
-        Ok(PsbtSignature {
+        Ok(BitcoinCheckpointSignature {
             unsigned_psbt: UnsignedPsbt(unsigned_psbt),
             signature,
             transfer_tx: BitcoinTx(transfer_tx),
+        })
+    }
+
+    /// This function asks the parent subnet (bitcoin) to generate the required transaction to perform the initial bootstrap handover.
+    /// The reason why this bootstrap handover is related to the way a subnet is created when the parent is bitcoin.
+    /// The RPC endpoint we use (`genbootstraphandover`) returns a PSBT and a number of signatures, same as the `gencheckpointpsbt` endpoint.
+    async fn get_bootstrap_handover_transaction(
+        &self,
+        subnet_id: &SubnetID,
+    ) -> Result<BitcoinHandoverSignature> {
+        tracing::info!("Creating bitcoin signatures for bootstrap handover: {subnet_id:?}");
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "genbootstraphandover",
+            "id": 1,
+            "params": {
+                "subnet_id": subnet_id.to_string(),
+            }
+        });
+
+        tracing::debug!("Request body: {body:?}");
+
+        let resp = self
+            .client
+            .post(self.rpc_url.clone())
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(anyhow!(
+                "genbootstraphandover request failed with status: {}",
+                resp.status()
+            ));
+        }
+
+        let data = resp.json::<Value>().await?;
+
+        if let Some(err_obj) = data.get("error") {
+            let code = err_obj
+                .get("code")
+                .and_then(Value::as_i64)
+                .unwrap_or_default();
+            let message = err_obj
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("Unknown error");
+            let error_data = err_obj
+                .get("data")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            return Err(anyhow!(
+                "JSON-RPC error: code={}, message={}, details={}",
+                code,
+                message,
+                error_data
+            ));
+        }
+
+        let unsigned_psbt = data
+            .get("result")
+            .and_then(|r| r.get("unsigned_psbt_base64"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("Missing 'result.unsigned_psbt_base64' in JSON-RPC response"))?
+            .to_string();
+
+        // The RPC call returns one signature for each input in the PSBT, hex encoded.
+        // We decode each signature and flatten the result into a single vector of bytes,
+        // which we then store in the `HandoverPsbtSignature` struct.
+        // When these signatures are submitted to the `finalizebootstraphandover` RPC call,
+        // they must be split again (see `split_signatures_and_zip_with_signatories`).
+        let signature = data
+        .get("result")
+        .and_then(|r| r.get("psbt_inputs_signatures"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("Missing 'result.psbt_inputs_signatures' in JSON-RPC response for bootstrap handover"))?
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Invalid entry in 'result.psbt_inputs_signatures' in JSON-RPC response for bootstrap handover"
+                    )
+                })
+                .and_then(|s| {
+                    hex::decode(s)
+                        .map_err(|e| anyhow!("decoding bitcoin signature failed: {}", e))
+                })
+        })
+        .collect::<Result<Vec<Vec<u8>>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<u8>>();
+
+        tracing::info!("BtcSubnetManager obtained bootstrap-handover PSBT and signatures.");
+
+        Ok(BitcoinHandoverSignature {
+            unsigned_psbt: UnsignedPsbt(unsigned_psbt),
+            signature,
         })
     }
 
@@ -1004,42 +1107,6 @@ impl SubnetManager for BtcSubnetManager {
     }
 }
 
-// In the `get_checkpoint_transaction` we concatenate the signatures of each signatory,
-// so we need to split them again here.
-// Example of what this code produces:
-// signatories_xonly_pubkey = vec![
-//     "5f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268",
-//     "67308c2f3915f4c36135f267ed709418c2880025d669e4ada7a206842d53c146",
-// ];
-//
-// split_signatures = vec![
-//     vec![
-//         "f245679ccda14b190213d4115ba8c10d484d5f0d1e0a37a493bd88f9fce3f05b5514debb23e83c693a1fdeb0622970fc3691dbbdee87b7430af41acdca58f44c",
-//         "ce02c09922cde3a671337baa86028a094d456a523286dccfcec015eff78fcf8b666db66c7368fe93f5d75fabf64451b2469931aab4386653194572261586e6dd",
-//     ],
-//     vec![
-//         "41592da0f93d2483ca227a75e36c8898d7097c61f56f2770ca8efe260b3d38011353edd64833cd6b5cc1b6e7c2be0b3a55fc55d5aa9cf34bfd4fa57d4ea551bf",
-//         "3e5f2635a43eab0560a038e300a5e1a4fb11cdfe0da4bf9842ca292db3538ff382d55ff05c2a32c412d558ff4333d0a0d16016b97b58971e16a93f43da01fe89",
-//     ],
-// ];
-//
-// And the resulting json will be:
-// "signatures_json": [
-//     [
-//         "5f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268",
-//         [
-//             "f245679ccda14b190213d4115ba8c10d484d5f0d1e0a37a493bd88f9fce3f05b5514debb23e83c693a1fdeb0622970fc3691dbbdee87b7430af41acdca58f44c",
-//             "ce02c09922cde3a671337baa86028a094d456a523286dccfcec015eff78fcf8b666db66c7368fe93f5d75fabf64451b2469931aab4386653194572261586e6dd"
-//         ]
-//     ],
-//     [
-//         "67308c2f3915f4c36135f267ed709418c2880025d669e4ada7a206842d53c146",
-//         [
-//             "ce02c09922cde3a671337baa86028a094d456a523286dccfcec015eff78fcf8b666db66c7368fe93f5d75fabf64451b2469931aab4386653194572261586e6dd",
-//             "3e5f2635a43eab0560a038e300a5e1a4fb11cdfe0da4bf9842ca292db3538ff382d55ff05c2a32c412d558ff4333d0a0d16016b97b58971e16a93f43da01fe89"
-//         ]
-//     ]
-// ]
 #[async_trait]
 impl BottomUpCheckpointRelayer for BtcSubnetManager {
     async fn submit_checkpoint(
@@ -1049,7 +1116,7 @@ impl BottomUpCheckpointRelayer for BtcSubnetManager {
         checkpoint: BottomUpCheckpoint,
         _signatures: Vec<Signature>,
         _signatories: Vec<Address>,
-        bitcoin_signatures: Option<PsbtSignatureQuorum>,
+        bitcoin_signatures: Option<BitcoinCheckpointSignatureQuorum>,
     ) -> anyhow::Result<ChainEpoch> {
         tracing::trace!("submitting checkpoint on btc with params: {checkpoint:?}");
         let bitcoin_signatures = match bitcoin_signatures {
@@ -1060,43 +1127,12 @@ impl BottomUpCheckpointRelayer for BtcSubnetManager {
                 ));
             }
         };
-        // Split the signatures of each signatory into chunks of 64 bytes (see info above function for more details)
-        let mut split_signatures = Vec::new();
-        for concatenated_signatures_of_signatory in bitcoin_signatures.signatures.iter() {
-            let split_signatures_of_signatory = concatenated_signatures_of_signatory
-                .chunks(libsecp256k1::util::SIGNATURE_SIZE)
-                .map(|chunk| hex::encode(chunk.to_vec()))
-                .collect::<Vec<_>>();
-            split_signatures.push(split_signatures_of_signatory);
-        }
-        // Replace the IPC addresses with the XOnlyPubKey, as the RPC expects the XOnlyPubKey
-        let signatories_xonly_pubkey = bitcoin_signatures
-            .signatories
-            .iter()
-            .map(|&s| -> Result<String> {
-                let sk = keystore
-                    .read()
-                    .map_err(|e| anyhow!("failed to read evm wallet: {e}"))?
-                    .get(&s.into())
-                    .map_err(|e| anyhow!("failed to get key from evm wallet: {e}"))?
-                    .ok_or_else(|| anyhow!("key {} does not exist in evm wallet", s))?
-                    .private_key()
-                    .to_vec();
-                let x_only_pub_key = hex::encode(
-                    ipc_wallet::get_xonly_public_key_serialized(&SecretKey::parse_slice(&sk)?)?
-                        .to_vec(),
-                );
-                Ok(x_only_pub_key)
-            })
-            .collect::<Result<Vec<String>>>()?;
 
-        // Construct the JSON array
-        let mut signatures_json = Vec::new();
-        for (signatory, signatures) in signatories_xonly_pubkey.iter().zip(split_signatures.iter())
-        {
-            let json_entry = json!([signatory, signatures]);
-            signatures_json.push(json_entry);
-        }
+        let signatures_json = split_signatures_and_zip_with_signatories(
+            bitcoin_signatures.signatures,
+            bitcoin_signatures.signatories,
+            &keystore,
+        )?;
 
         let body = json!({
             "jsonrpc": "2.0",
@@ -1246,6 +1282,166 @@ impl BottomUpCheckpointRelayer for BtcSubnetManager {
         tracing::info!("getting current epoch on bitcoin");
         anyhow::bail!("not supported on btc, it is not meant to be a child subnet")
     }
+
+    async fn submit_bootstrap_handover(
+        &self,
+        subnet_id: &SubnetID,
+        keystore: Arc<RwLock<PersistentKeyStore<EthKeyAddress>>>,
+        handover_signatures: ipc_api::checkpoint::BitcoinHandoverSignatureQuorum,
+    ) -> Result<ChainEpoch> {
+        tracing::info!("submitting bootstrap handover transaction on btc");
+
+        let signatures_json = split_signatures_and_zip_with_signatories(
+            handover_signatures.signatures,
+            handover_signatures.signatories,
+            &keystore,
+        )?;
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "finalizebootstraphandover",
+            "id": 1,
+            "params": {
+                "subnet_id":            subnet_id.to_string(),
+                "unsigned_psbt_base64": handover_signatures.unsigned_psbt.0,
+                "signatures":           signatures_json,
+            }
+        });
+
+        tracing::debug!("Request body: {body:#?}");
+
+        let resp = self
+            .client
+            .post(self.rpc_url.clone())
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(anyhow!(
+                "finalizebootstraphandover request failed with status: {}",
+                resp.status()
+            ));
+        }
+
+        let data = resp.json::<Value>().await?;
+
+        if let Some(err_obj) = data.get("error") {
+            let code = err_obj
+                .get("code")
+                .and_then(Value::as_i64)
+                .unwrap_or_default();
+            let message = err_obj
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("Unknown error");
+            let error_data = err_obj
+                .get("data")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            return Err(anyhow!(
+                "JSON-RPC error: code={}, message={}, details={}",
+                code,
+                message,
+                error_data
+            ));
+        }
+
+        let current_height = self.chain_head_height().await?;
+
+        tracing::info!("bootstrap handover submitted on btc at height: {current_height:}");
+        Ok(current_height)
+    }
+
+    async fn get_bootstrap_handover_signatures(
+        &self,
+        _height: ChainEpoch,
+    ) -> Result<ipc_api::checkpoint::BitcoinHandoverSignatureQuorum> {
+        anyhow::bail!("not supported on btc, it is not meant to be a child subnet")
+    }
+}
+
+// The `signatures` contains, for each signatory, multiple concatenated signatures from that signatory.
+// The `signatories` contains the ethereum addresses of the signatories.
+// (see the `get_checkpoint_transaction` for how this is created, we concatenate the signatures of each signatory).
+//
+// We need to split them again here, and then zip them with the XOnly public keys of the signatories,
+// because that's how the RPC methods `finalizebootstraphandover` and `finalizecheckpointpsbt` expect them.
+//
+// Example of what this code produces:
+// signatories_xonly_pubkey = vec![
+//     "5f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268",
+//     "67308c2f3915f4c36135f267ed709418c2880025d669e4ada7a206842d53c146",
+// ];
+//
+// split_signatures = vec![
+//     vec![
+//         "f245679ccda14b190213d4115ba8c10d484d5f0d1e0a37a493bd88f9fce3f05b5514debb23e83c693a1fdeb0622970fc3691dbbdee87b7430af41acdca58f44c",
+//         "ce02c09922cde3a671337baa86028a094d456a523286dccfcec015eff78fcf8b666db66c7368fe93f5d75fabf64451b2469931aab4386653194572261586e6dd",
+//     ],
+//     vec![
+//         "41592da0f93d2483ca227a75e36c8898d7097c61f56f2770ca8efe260b3d38011353edd64833cd6b5cc1b6e7c2be0b3a55fc55d5aa9cf34bfd4fa57d4ea551bf",
+//         "3e5f2635a43eab0560a038e300a5e1a4fb11cdfe0da4bf9842ca292db3538ff382d55ff05c2a32c412d558ff4333d0a0d16016b97b58971e16a93f43da01fe89",
+//     ],
+// ];
+//
+// "signatures_json": [
+//     [
+//         "5f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268",
+//         [
+//             "f245679ccda14b190213d4115ba8c10d484d5f0d1e0a37a493bd88f9fce3f05b5514debb23e83c693a1fdeb0622970fc3691dbbdee87b7430af41acdca58f44c",
+//             "ce02c09922cde3a671337baa86028a094d456a523286dccfcec015eff78fcf8b666db66c7368fe93f5d75fabf64451b2469931aab4386653194572261586e6dd"
+//         ]
+//     ],
+//     [
+//         "67308c2f3915f4c36135f267ed709418c2880025d669e4ada7a206842d53c146",
+//         [
+//             "ce02c09922cde3a671337baa86028a094d456a523286dccfcec015eff78fcf8b666db66c7368fe93f5d75fabf64451b2469931aab4386653194572261586e6dd",
+//             "3e5f2635a43eab0560a038e300a5e1a4fb11cdfe0da4bf9842ca292db3538ff382d55ff05c2a32c412d558ff4333d0a0d16016b97b58971e16a93f43da01fe89"
+//         ]
+//     ]
+// ]
+fn split_signatures_and_zip_with_signatories(
+    signatures: Vec<BitcoinSignature>,
+    signatories: Vec<ethers::types::Address>,
+    keystore: &Arc<RwLock<PersistentKeyStore<EthKeyAddress>>>,
+) -> Result<Vec<serde_json::Value>> {
+    // Split the signatures of each signatory into chunks of 64 bytes (see info above function for more details)
+    let mut split_signatures = Vec::new();
+    for concatenated_signatures_of_signatory in signatures.iter() {
+        let split_signatures_of_signatory = concatenated_signatures_of_signatory
+            .chunks(libsecp256k1::util::SIGNATURE_SIZE)
+            .map(|chunk| hex::encode(chunk.to_vec()))
+            .collect::<Vec<_>>();
+        split_signatures.push(split_signatures_of_signatory);
+    }
+    // Replace the IPC addresses with the XOnlyPubKey, as the RPC expects the XOnlyPubKey
+    let signatories_xonly_pubkey = signatories
+        .iter()
+        .map(|&s| -> Result<String> {
+            let sk = keystore
+                .read()
+                .map_err(|e| anyhow!("failed to read evm wallet: {e}"))?
+                .get(&s.into())
+                .map_err(|e| anyhow!("failed to get key from evm wallet: {e}"))?
+                .ok_or_else(|| anyhow!("key {} does not exist in evm wallet", s))?
+                .private_key()
+                .to_vec();
+            let x_only_pub_key = hex::encode(
+                ipc_wallet::get_xonly_public_key_serialized(&SecretKey::parse_slice(&sk)?)?
+                    .to_vec(),
+            );
+            Ok(x_only_pub_key)
+        })
+        .collect::<Result<Vec<String>>>()?;
+
+    // Construct the JSON array
+    let mut signatures_json = Vec::new();
+    for (signatory, signatures) in signatories_xonly_pubkey.iter().zip(split_signatures.iter()) {
+        let json_entry = json!([signatory, signatures]);
+        signatures_json.push(json_entry);
+    }
+    Ok(signatures_json)
 }
 
 #[async_trait]

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -13,7 +13,7 @@ use ipc_actors_abis::{
     subnet_actor_activity_facet, subnet_actor_checkpointing_facet, subnet_actor_getter_facet,
     subnet_actor_manager_facet, subnet_actor_reward_facet,
 };
-use ipc_api::checkpoint::{BottomUpCheckpointBundle, PsbtSignatureQuorum};
+use ipc_api::checkpoint::{BitcoinCheckpointSignatureQuorum, BottomUpCheckpointBundle};
 use ipc_api::evm::{fil_to_eth_amount, payload_to_evm_address, subnet_id_to_evm_addresses};
 use ipc_api::validator::from_contract_validators;
 use reqwest::header::HeaderValue;
@@ -1043,10 +1043,17 @@ impl SubnetManager for EthSubnetManager {
         &self,
         _subnet_id: &SubnetID,
         _checkpoint: BottomUpCheckpoint,
-    ) -> Result<ipc_api::checkpoint::PsbtSignature> {
+    ) -> Result<ipc_api::checkpoint::BitcoinCheckpointSignature> {
         unimplemented!(
             "Checkpointing on evm parent subnets does not need to contact the parent subnet"
         )
+    }
+
+    async fn get_bootstrap_handover_transaction(
+        &self,
+        _subnet_id: &SubnetID,
+    ) -> Result<ipc_api::checkpoint::BitcoinHandoverSignature> {
+        unimplemented!("Bootstrap handover is only required for bitcoin parent subnet")
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -1297,7 +1304,7 @@ impl BottomUpCheckpointRelayer for EthSubnetManager {
         checkpoint: BottomUpCheckpoint,
         signatures: Vec<Signature>,
         signatories: Vec<Address>,
-        bitcoin_signatures: Option<PsbtSignatureQuorum>,
+        bitcoin_signatures: Option<BitcoinCheckpointSignatureQuorum>,
     ) -> anyhow::Result<ChainEpoch> {
         if bitcoin_signatures != None {
             return Err(anyhow!(
@@ -1416,29 +1423,29 @@ impl BottomUpCheckpointRelayer for EthSubnetManager {
                 Arc::new(self.ipc_contract_info.provider.clone()),
             );
 
-            let (psbt, batch_transfer_tx, signatories, signatures) = contract
+            let (psbt, batch_transfer_tx, bitcoin_signatories, bitcoin_signatures) = contract
                 .get_bitcoin_checkpoint_signatures(U256::from(height))
                 .call()
                 .await?;
 
-            if signatories.len() != signatures.len() {
+            if bitcoin_signatories.len() != bitcoin_signatures.len() {
                 return Err(anyhow!(
                     "signatories and signatures length mismatch for bitcoin checkpoint at height: {}",
                     height
                 ));
             }
 
-            tracing::debug!("found {} bitcoin signatures", signatures.len());
+            tracing::debug!("found {} bitcoin signatures", bitcoin_signatures.len());
 
-            let signatures = signatures
+            let bitcoin_signatures = bitcoin_signatures
                 .into_iter()
                 .map(|s| s.to_vec())
                 .collect::<Vec<_>>();
 
-            Some(PsbtSignatureQuorum {
+            Some(BitcoinCheckpointSignatureQuorum {
                 unsigned_psbt: ipc_api::checkpoint::UnsignedPsbt::encode(&psbt)?,
-                signatories,
-                signatures,
+                signatories: bitcoin_signatories,
+                signatures: bitcoin_signatures,
                 transfer_tx: ipc_api::checkpoint::BitcoinTx::encode(&batch_transfer_tx)?,
             })
         // } else {
@@ -1485,6 +1492,54 @@ impl BottomUpCheckpointRelayer for EthSubnetManager {
             .await?
             .as_u64();
         Ok(epoch as ChainEpoch)
+    }
+
+    async fn submit_bootstrap_handover(
+        &self,
+        _subnet_id: &SubnetID,
+        _keystore: Arc<RwLock<PersistentKeyStore<EthKeyAddress>>>,
+        _handover_signatures: ipc_api::checkpoint::BitcoinHandoverSignatureQuorum,
+    ) -> anyhow::Result<ChainEpoch> {
+        anyhow::bail!("handover does not need to be submitted on evm")
+    }
+
+    async fn get_bootstrap_handover_signatures(
+        &self,
+        height: ChainEpoch,
+    ) -> anyhow::Result<ipc_api::checkpoint::BitcoinHandoverSignatureQuorum> {
+        tracing::debug!(
+            "getting bitcoin checkpoint signatures for checkpoint at height: {}",
+            height
+        );
+        let contract = checkpointing_facet::CheckpointingFacet::new(
+            self.ipc_contract_info.gateway_addr,
+            Arc::new(self.ipc_contract_info.provider.clone()),
+        );
+
+        let (psbt, signatories, signatures) = contract
+            .get_bitcoin_bootstrap_handover_signatures()
+            .call()
+            .await?;
+
+        if signatories.len() != signatures.len() {
+            return Err(anyhow!(
+                "signatories and signatures length mismatch for bitcoin handover at height: {}",
+                height
+            ));
+        }
+
+        tracing::debug!("found {} bitcoin signatures", signatures.len());
+
+        let signatures = signatures
+            .into_iter()
+            .map(|s| s.to_vec())
+            .collect::<Vec<_>>();
+
+        Ok(ipc_api::checkpoint::BitcoinHandoverSignatureQuorum {
+            unsigned_psbt: ipc_api::checkpoint::UnsignedPsbt::encode(&psbt)?,
+            signatories,
+            signatures,
+        })
     }
 }
 

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -216,7 +216,14 @@ pub trait SubnetManager:
         &self,
         subnet_id: &SubnetID,
         checkpoint: BottomUpCheckpoint,
-    ) -> Result<ipc_api::checkpoint::PsbtSignature>;
+    ) -> Result<ipc_api::checkpoint::BitcoinCheckpointSignature>;
+
+    /// This function asks the parent subnet (bitcoin) to generate the required transaction for the initial handover.
+    /// It is only required when the parent subnet is bitcoin.
+    async fn get_bootstrap_handover_transaction(
+        &self,
+        subnet_id: &SubnetID,
+    ) -> Result<ipc_api::checkpoint::BitcoinHandoverSignature>;
 
     fn as_any(&self) -> &dyn Any;
 }
@@ -288,7 +295,7 @@ pub trait BottomUpCheckpointRelayer: Send + Sync {
         checkpoint: BottomUpCheckpoint,
         signatures: Vec<Signature>,
         signatories: Vec<Address>,
-        bitcoin_signatures: Option<ipc_api::checkpoint::PsbtSignatureQuorum>,
+        bitcoin_signatures: Option<ipc_api::checkpoint::BitcoinCheckpointSignatureQuorum>,
     ) -> Result<ChainEpoch>;
     /// The last confirmed/submitted checkpoint height.
     async fn last_bottom_up_checkpoint_height(&self, subnet_id: &SubnetID) -> Result<ChainEpoch>;
@@ -303,6 +310,21 @@ pub trait BottomUpCheckpointRelayer: Send + Sync {
     async fn quorum_reached_events(&self, height: ChainEpoch) -> Result<Vec<QuorumReachedEvent>>;
     /// Get the current epoch in the current subnet
     async fn current_epoch(&self) -> Result<ChainEpoch>;
+
+    /// Submit a bootstrap handover signature for the given subnet.
+    /// Used only when the parent subnet is bitcoin.
+    async fn submit_bootstrap_handover(
+        &self,
+        subnet_id: &SubnetID,
+        keystore: Arc<RwLock<PersistentKeyStore<EthKeyAddress>>>,
+        handover_signatures: ipc_api::checkpoint::BitcoinHandoverSignatureQuorum,
+    ) -> Result<ChainEpoch>;
+
+    /// Get the bootstrap handover signatures.
+    async fn get_bootstrap_handover_signatures(
+        &self,
+        height: ChainEpoch,
+    ) -> Result<ipc_api::checkpoint::BitcoinHandoverSignatureQuorum>;
 }
 
 /// The validator reward related functions, such as check reward and claim reward for mining blocks


### PR DESCRIPTION
This PR implements the contract methods and logic for validators and relayer so as to obtain signatures for handover from bitcoin-ipc, store them in the subnet, retrieve when relayer requests them, and submit the handover transaction to bitcoin.