### PR TITLE
bug: IPC-BTC allocation with decimals; small fixes for better UI/UX

### DIFF
--- a/fendermint/vm/interpreter/src/fvm/reward_mint.rs
+++ b/fendermint/vm/interpreter/src/fvm/reward_mint.rs
@@ -118,29 +118,29 @@ where
         let reward_token: ContractCaller<DB, RewardToken<MockProvider>, NoRevert> =
             ContractCaller::new(token_addr, RewardToken::new);
 
-        // tokens_per_snapshot is in whole tokens; scale to wei for ERC20 mint (18 decimals).
+        // Each validator's share is collateral/total of tokens_per_snapshot whole tokens, scales to wei (18 decimals)
         let unit = 10u128.pow(ipc::ipc_btc::DECIMALS as u32);
+        let scaled_per_snapshot = et::U256::from(tokens_per_snapshot) * et::U256::from(unit);
+        let total = et::U256::from(total);
 
         for (addr, amount_sats) in &response.collaterals {
-            let amount = *amount_sats as u128;
-            let mint_tokens = (amount * tokens_per_snapshot) / total;
-            if mint_tokens == 0 {
+            let mint_amount = et::U256::from(*amount_sats as u128) * scaled_per_snapshot / total;
+            if mint_amount.is_zero() {
                 continue;
             }
-            let mint_amount = et::U256::from(mint_tokens * unit);
             // Keep `.from(...)` unset so ContractCaller defaults to system::SYSTEM_ACTOR_ADDR (t00).
             match reward_token.call_with_return(state, |c| c.mint(*addr, mint_amount)) {
                 Ok(_) => {
                     tracing::info!(
                         addr = %addr,
-                        mint_amount = mint_tokens,
+                        mint_amount = %mint_amount,
                         "reward minted successfully"
                     );
                 }
                 Err(e) => {
                     tracing::warn!(
                         addr = %addr,
-                        mint_amount = %mint_tokens,
+                        mint_amount = %mint_amount,
                         error = %e,
                         "reward mint failed for address, skipping"
                     );

--- a/ipc/cli/src/commands/crossmsg/query_token_metadata.rs
+++ b/ipc/cli/src/commands/crossmsg/query_token_metadata.rs
@@ -34,6 +34,14 @@ impl CommandLineHandler for QueryTokenMetadata {
             .get_token_metadata(&subnet, gateway_addr, home_subnet.clone(), home_token)
             .await?;
 
+        if metadata.name.is_empty() && metadata.symbol.is_empty() {
+            println!(
+                "Token ({}, {}) is not registered on subnet {}",
+                arguments.home_subnet, arguments.home_token, arguments.subnet
+            );
+            return Ok(());
+        }
+
         let wrapped_token = if subnet == home_subnet {
             None
         } else {

--- a/ipc/provider/src/config/subnet.rs
+++ b/ipc/provider/src/config/subnet.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::time::Duration;
 
 // Copyright 2022-2024 Protocol Labs
@@ -74,8 +73,10 @@ impl Subnet {
         match &self.config {
             SubnetConfig::Fevm(s) => s.gateway_addr,
             SubnetConfig::Btc(_s) => {
-                // TODO(btc) placeholder
-                Address::from_str("0x0000000000000000000000000000000000000000").unwrap()
+                // TODO(btc) placeholder — Btc subnets have no FVM gateway address. Use the
+                // zero ID address; parsing a 0x-hex string here is not a valid FVM address
+                // and panics with UnknownNetwork.
+                Address::new_id(0)
             }
         }
     }

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -804,7 +804,13 @@ impl SubnetManager for EthSubnetManager {
         );
         let txn = gateway_contract.transfer_erc(to_addr, evm_dst_subnet, local_token_addr, value);
         let txn = extend_call_with_pending_block(txn).await?;
-        let pending_tx = txn.send().await?;
+        let pending_tx = txn.send().await.map_err(|e| {
+            // translate raw 4-byte selectors into readable messages
+            match decode_transfer_erc_revert(&format!("{e} {e:?}")) {
+                Some(msg) => anyhow!("transfer-erc failed: {msg}"),
+                None => anyhow!("transfer-erc gateway call failed: {e}"),
+            }
+        })?;
         let receipt = pending_tx.retries(TRANSACTION_RECEIPT_RETRIES).await?;
         block_number_from_receipt(receipt)
     }
@@ -1934,6 +1940,44 @@ where
     M: ethers::abi::Detokenize,
 {
     Ok(call.block(ethers::types::BlockNumber::Pending))
+}
+
+/// Translates a gateway/ERC20 revert selector surfaced during `transfer-erc` into a
+/// human-readable message.
+/// Returns None for unrecognized reverts so the caller keeps the original error.
+fn decode_transfer_erc_revert(text: &str) -> Option<&'static str> {
+    const KNOWN: &[(&str, &str)] = &[
+        // Gateway-side (source subnet) checks
+        ("0xa17124f8", "insufficient token balance for this transfer"),
+        (
+            "0xdc98d7bb",
+            "gateway is not approved to spend enough of this token",
+        ),
+        ("0x29c54429", "transfer amount must be greater than zero"),
+        (
+            "0x259ba1ad",
+            "token is not registered as bridgeable on this subnet",
+        ),
+        (
+            "0x8cbeca14",
+            "token metadata not found — token is not registered on this subnet",
+        ),
+        (
+            "0x78e83826",
+            "IPC-BTC token is not configured on this subnet",
+        ),
+        // OpenZeppelin ERC20 reverts (e.g. from a wrapped token on the destination)
+        ("0xe450d38c", "insufficient token balance for this transfer"),
+        (
+            "0xfb8f41b2",
+            "gateway is not approved to spend enough of this token",
+        ),
+        ("0xec442f05", "transfer recipient is invalid (zero address)"),
+    ];
+    KNOWN
+        .iter()
+        .find(|(selector, _)| text.contains(selector))
+        .map(|(_, msg)| *msg)
 }
 
 /// Get the block number from the transaction receipt


### PR DESCRIPTION
- compute rewards in wei (small denomination) so that decimals are not lost
- show meaningful messages for failed cross-subnet transfers
- fix empty gateway address for BTC parent
- better output for query-token-metadata